### PR TITLE
Adds Shipping BC

### DIFF
--- a/ecommerce/shipping/.mutant.yml
+++ b/ecommerce/shipping/.mutant.yml
@@ -1,0 +1,12 @@
+requires:
+  - ./test/test_helper
+integration: minitest
+coverage_criteria:
+  process_abort: true
+matcher:
+  subjects:
+    - Shipping*
+  ignore:
+    - Shipping::Test*
+    - Shipping::Configuration#initialize
+    - Shipping::Configuration#call

--- a/ecommerce/shipping/Gemfile
+++ b/ecommerce/shipping/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+eval_gemfile "../../infra/Gemfile.test"
+gem "infra", path: "../../infra"

--- a/ecommerce/shipping/Gemfile.lock
+++ b/ecommerce/shipping/Gemfile.lock
@@ -1,0 +1,132 @@
+PATH
+  remote: ../../infra
+  specs:
+    infra (1.0.0)
+      dry-struct
+      dry-types
+      rails_event_store (~> 2.3.0)
+      rake
+      ruby_event_store-transformations
+
+GEM
+  remote: https://rubygems.org/
+  remote: https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev/
+  specs:
+    activejob (6.1.4.1)
+      activesupport (= 6.1.4.1)
+      globalid (>= 0.3.6)
+    activemodel (6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activerecord (6.1.4.1)
+      activemodel (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activerecord-import (1.2.0)
+      activerecord (>= 3.2)
+    activesupport (6.1.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    aggregate_root (2.3.0)
+      ruby2_keywords
+      ruby_event_store (= 2.3.0)
+    arkency-command_bus (0.4.0)
+      thread_safe
+    ast (2.4.2)
+    concurrent-ruby (1.1.9)
+    diff-lcs (1.4.4)
+    dry-configurable (0.13.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.6)
+    dry-container (0.9.0)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.13, >= 0.13.0)
+    dry-core (0.7.1)
+      concurrent-ruby (~> 1.0)
+    dry-inflector (0.2.1)
+    dry-logic (1.2.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.5, >= 0.5)
+    dry-struct (1.4.0)
+      dry-core (~> 0.5, >= 0.5)
+      dry-types (~> 1.5)
+      ice_nine (~> 0.11)
+    dry-types (1.5.1)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.3)
+      dry-core (~> 0.5, >= 0.5)
+      dry-inflector (~> 0.1, >= 0.1.2)
+      dry-logic (~> 1.0, >= 1.0.2)
+    globalid (0.5.2)
+      activesupport (>= 5.0)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
+    minitest (5.14.4)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    mutant (0.10.34)
+      diff-lcs (~> 1.3)
+      parser (~> 3.0.0)
+      regexp_parser (~> 2.0, >= 2.0.3)
+      unparser (~> 0.6.0)
+    mutant-license (0.1.1.2.1627430819213747598431630701693729869473.4)
+    mutant-minitest (0.10.34)
+      minitest (~> 5.11)
+      mutant (= 0.10.34)
+    parser (3.0.2.0)
+      ast (~> 2.4.1)
+    rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
+    rails_event_store (2.3.0)
+      activejob (>= 3.0)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      aggregate_root (= 2.3.0)
+      arkency-command_bus (>= 0.4)
+      rails_event_store_active_record (= 2.3.0)
+      ruby_event_store (= 2.3.0)
+      ruby_event_store-browser (= 2.3.0)
+    rails_event_store_active_record (2.3.0)
+      activerecord (>= 5.0)
+      activerecord-import (>= 1.0.2)
+      ruby_event_store (= 2.3.0)
+    rake (13.0.6)
+    regexp_parser (2.1.1)
+    ruby2_keywords (0.0.5)
+    ruby_event_store (2.3.0)
+      concurrent-ruby (~> 1.0, >= 1.1.6)
+      ruby2_keywords
+    ruby_event_store-browser (2.3.0)
+      ruby_event_store (= 2.3.0)
+      sinatra
+    ruby_event_store-transformations (0.1.0)
+      activesupport (>= 5.0)
+      ruby_event_store (>= 2.0.0, < 3.0.0)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    thread_safe (0.3.6)
+    tilt (2.0.10)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    unparser (0.6.0)
+      diff-lcs (~> 1.3)
+      parser (>= 3.0.0)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  infra!
+  minitest!
+  mutant-license!
+  mutant-minitest!
+
+BUNDLED WITH
+   2.1.4

--- a/ecommerce/shipping/Makefile
+++ b/ecommerce/shipping/Makefile
@@ -1,0 +1,10 @@
+install:
+	@bundle install
+
+test:
+	@bundle exec ruby -e "require \"rake/rake_test_loader\"" test/*_test.rb
+
+mutate:
+	@RAILS_ENV=test bundle exec mutant run
+
+.PHONY: install test mutate

--- a/ecommerce/shipping/README.md
+++ b/ecommerce/shipping/README.md
@@ -1,0 +1,9 @@
+# Shipping
+
+[![Build Status](https://github.com/RailsEventStore/cqrs-es-sample-with-res/workflows/inventory/badge.svg)](https://github.com/RailsEventStore/cqrs-es-sample-with-res/actions/workflows/shipping.yml)
+
+#### Up and running
+
+```
+make install test mutate
+```

--- a/ecommerce/shipping/lib/shipping.rb
+++ b/ecommerce/shipping/lib/shipping.rb
@@ -1,0 +1,19 @@
+require "infra"
+require_relative "shipping/commands/add_item_to_shipment_picking_list"
+require_relative "shipping/events/item_added_to_shipment_picking_list"
+require_relative "shipping/services/on_add_item_to_shipment_picking_list"
+
+require_relative "shipping/shipment"
+
+module Shipping
+  class Configuration
+    def call(event_store, command_bus)
+      cqrs = Infra::Cqrs.new(event_store, command_bus)
+
+      cqrs.register(
+        AddItemToShipmentPickingList,
+        OnAddItemToShipmentPickingList.new(event_store)
+      )
+    end
+  end
+end

--- a/ecommerce/shipping/lib/shipping.rb
+++ b/ecommerce/shipping/lib/shipping.rb
@@ -3,6 +3,10 @@ require_relative "shipping/commands/add_item_to_shipment_picking_list"
 require_relative "shipping/events/item_added_to_shipment_picking_list"
 require_relative "shipping/services/on_add_item_to_shipment_picking_list"
 
+require_relative "shipping/commands/remove_item_from_shipment_picking_list"
+require_relative "shipping/events/item_removed_from_shipment_picking_list"
+require_relative "shipping/services/on_remove_item_from_shipment_picking_list"
+
 require_relative "shipping/shipment"
 
 module Shipping
@@ -13,6 +17,10 @@ module Shipping
       cqrs.register(
         AddItemToShipmentPickingList,
         OnAddItemToShipmentPickingList.new(event_store)
+      )
+      cqrs.register(
+        RemoveItemFromShipmentPickingList,
+        OnRemoveItemFromShipmentPickingList.new(event_store)
       )
     end
   end

--- a/ecommerce/shipping/lib/shipping/commands/add_item_to_shipment_picking_list.rb
+++ b/ecommerce/shipping/lib/shipping/commands/add_item_to_shipment_picking_list.rb
@@ -1,0 +1,8 @@
+module Shipping
+  class AddItemToShipmentPickingList < Infra::Command
+    attribute :order_id, Infra::Types::UUID
+    attribute :product_id, Infra::Types::UUID
+
+    alias aggregate_id order_id
+  end
+end

--- a/ecommerce/shipping/lib/shipping/commands/remove_item_from_shipment_picking_list.rb
+++ b/ecommerce/shipping/lib/shipping/commands/remove_item_from_shipment_picking_list.rb
@@ -1,0 +1,8 @@
+module Shipping
+  class RemoveItemFromShipmentPickingList < Infra::Command
+    attribute :order_id, Infra::Types::UUID
+    attribute :product_id, Infra::Types::UUID
+
+    alias aggregate_id order_id
+  end
+end

--- a/ecommerce/shipping/lib/shipping/events/item_added_to_shipment_picking_list.rb
+++ b/ecommerce/shipping/lib/shipping/events/item_added_to_shipment_picking_list.rb
@@ -1,0 +1,6 @@
+module Shipping
+  class ItemAddedToShipmentPickingList < Infra::Event
+    attribute :order_id, Infra::Types::UUID
+    attribute :product_id, Infra::Types::UUID
+  end
+end

--- a/ecommerce/shipping/lib/shipping/events/item_removed_from_shipment_picking_list.rb
+++ b/ecommerce/shipping/lib/shipping/events/item_removed_from_shipment_picking_list.rb
@@ -1,0 +1,6 @@
+module Shipping
+  class ItemRemovedFromShipmentPickingList < Infra::Event
+    attribute :order_id, Infra::Types::UUID
+    attribute :product_id, Infra::Types::UUID
+  end
+end

--- a/ecommerce/shipping/lib/shipping/services/on_add_item_to_shipment_picking_list.rb
+++ b/ecommerce/shipping/lib/shipping/services/on_add_item_to_shipment_picking_list.rb
@@ -1,0 +1,16 @@
+module Shipping
+  class OnAddItemToShipmentPickingList
+    def initialize(event_store)
+      @repository = AggregateRoot::Repository.new(event_store)
+    end
+
+    def call(command)
+      @repository.with_aggregate(
+        Shipment.new(command.order_id),
+        "Shipping::Shipment$#{command.order_id}"
+      ) do |shipment| 
+        shipment.add_item(command.product_id)
+      end
+    end
+  end
+end

--- a/ecommerce/shipping/lib/shipping/services/on_remove_item_from_shipment_picking_list.rb
+++ b/ecommerce/shipping/lib/shipping/services/on_remove_item_from_shipment_picking_list.rb
@@ -1,0 +1,16 @@
+module Shipping
+  class OnRemoveItemFromShipmentPickingList
+    def initialize(event_store)
+      @repository = AggregateRoot::Repository.new(event_store)
+    end
+
+    def call(command)
+      @repository.with_aggregate(
+        Shipment.new(command.order_id),
+        "Shipping::Shipment$#{command.order_id}"
+      ) do |shipment|
+        shipment.remove_item(command.product_id)
+      end
+    end
+  end
+end

--- a/ecommerce/shipping/lib/shipping/shipment.rb
+++ b/ecommerce/shipping/lib/shipping/shipment.rb
@@ -1,0 +1,72 @@
+module Shipping
+  class Shipment
+    include AggregateRoot
+
+    def initialize(order_id)
+      @order_id = order_id
+      @picking_list = PickingList.new
+      @state = :draft
+    end
+
+    def add_item(product_id)
+      apply ItemAddedToShipmentPickingList.new(
+        data: {
+          order_id: @order_id,
+          product_id: product_id
+        }
+      )
+    end
+
+    private
+
+    on ItemAddedToShipmentPickingList do |event| 
+      @picking_list.increase_item_quantity(event.data.fetch(:product_id))
+    end
+  end
+
+  class PickingList
+    attr_reader :items
+
+    def initialize
+      @items = []
+    end
+
+    def increase_item_quantity(product_id)
+      item = find_or_add_item(product_id)
+      item.increase
+    end
+
+    private
+    
+    def find_or_add_item(product_id)
+      find_item(product_id) || add_item(product_id)
+    end
+
+    def find_item(product_id)
+      items.find {|i| i.product_id == product_id }
+    end
+    
+    def add_item(product_id)
+      item = PickingListItem.new(product_id)
+      items << item
+      item
+    end
+  end
+
+  class PickingListItem
+    attr_reader :product_id, :quantity
+
+    def initialize(product_id)
+      @product_id = product_id
+      @quantity = 0
+    end
+
+    def increase
+      @quantity += 1
+    end
+
+    def decrease
+      @quantity -= 1
+    end
+  end
+end

--- a/ecommerce/shipping/test/on_add_item_to_shipment_picking_list_test.rb
+++ b/ecommerce/shipping/test/on_add_item_to_shipment_picking_list_test.rb
@@ -1,0 +1,23 @@
+require_relative "test_helper"
+
+module Shipping
+  class OnAddItemToShipmentPickingListTest < Test
+    cover "Shipping::OnAddItemToShipmentPickingList*"
+
+    def test_add_item_to_shipment_picking_list
+      order_id = SecureRandom.uuid
+      product_id = SecureRandom.uuid
+      stream = "Shipping::Shipment$#{order_id}"
+
+      assert_events(
+        stream,
+        ItemAddedToShipmentPickingList.new(
+          data: {
+            order_id: order_id,
+            product_id: product_id
+          }
+        )
+      ) { act(AddItemToShipmentPickingList.new(order_id: order_id, product_id: product_id)) }
+    end
+  end
+end

--- a/ecommerce/shipping/test/on_remove_item_from_shipment_picking_list_test.rb
+++ b/ecommerce/shipping/test/on_remove_item_from_shipment_picking_list_test.rb
@@ -1,0 +1,41 @@
+require_relative "test_helper"
+
+module Shipping
+  class OnRemoveItemFromShipmentPickingListTest < Test
+    cover "Shipping::OnRemoveItemFromShipmentPickingList*"
+
+    def test_remove_item_from_shipment_picking_list
+      order_id = SecureRandom.uuid
+      product_id = SecureRandom.uuid
+      stream = "Shipping::Shipment$#{order_id}"
+
+      run_command(AddItemToShipmentPickingList.new(
+        order_id: order_id,
+        product_id: product_id
+      ))
+
+      assert_events(
+        stream,
+        ItemRemovedFromShipmentPickingList.new(
+          data: {
+            order_id: order_id,
+            product_id: product_id
+          }
+        )
+      ) { act(RemoveItemFromShipmentPickingList.new(order_id: order_id, product_id: product_id)) }
+    end
+
+    def test_should_not_allow_removing_non_existing_items
+      order_id = SecureRandom.uuid
+      product_id = SecureRandom.uuid
+      stream = "Shipping::Shipment$#{order_id}"
+
+      assert_raises(Shipment::ItemNotFound) do
+        act(RemoveItemFromShipmentPickingList.new(
+          order_id: order_id,
+          product_id: product_id
+        ))
+      end
+    end
+  end
+end

--- a/ecommerce/shipping/test/shipment_test.rb
+++ b/ecommerce/shipping/test/shipment_test.rb
@@ -1,0 +1,65 @@
+require_relative "test_helper"
+
+module Shipping
+  class ShipmentTest < Test
+    cover "Shipping::Shipment*"
+
+    def test_add_item_publishes_event
+      product_id = SecureRandom.uuid
+      shipment = Shipment.new(order_id)
+
+      shipment.add_item(product_id)
+
+      assert_changes(
+        shipment.unpublished_events,
+        [
+          ItemAddedToShipmentPickingList.new(
+            data: {
+              order_id: order_id,
+              product_id: product_id
+            }
+          )
+        ]
+      )
+    end
+
+    def test_remove_item_publishes_event
+      product_id = SecureRandom.uuid
+      shipment = Shipment.new(order_id)
+
+      shipment.add_item(product_id)
+      shipment.remove_item(product_id)
+
+      assert_changes(
+        shipment.unpublished_events,
+        [
+          ItemAddedToShipmentPickingList.new(
+            data: {
+              order_id: order_id,
+              product_id: product_id
+            }
+          ),
+          ItemRemovedFromShipmentPickingList.new(
+            data: {
+              order_id: order_id,
+              product_id: product_id
+            }
+          )
+        ]
+      )
+    end
+
+    def test_should_not_allow_removing_non_existing_items
+      product_id = SecureRandom.uuid
+      shipment = Shipment.new(order_id)
+
+      assert_raises(Shipment::ItemNotFound) { shipment.remove_item(product_id)  }
+    end
+
+    private
+
+    def order_id
+      @order_id ||= SecureRandom.uuid
+    end
+  end
+end

--- a/ecommerce/shipping/test/test_helper.rb
+++ b/ecommerce/shipping/test/test_helper.rb
@@ -1,0 +1,17 @@
+require "minitest/autorun"
+require "mutant/minitest/coverage"
+
+require_relative "../../pricing/lib/pricing"
+require_relative "../../shipping/lib/shipping"
+
+module Shipping
+  class Test < Infra::InMemoryTest
+
+    def before_setup
+      super
+      [
+        Shipping::Configuration.new
+      ].each { |c| c.call(event_store, command_bus) }
+    end
+  end
+end

--- a/rails_application/lib/configuration.rb
+++ b/rails_application/lib/configuration.rb
@@ -158,7 +158,18 @@ module Ecommerce
           )
         end,
         [Pricing::ItemAddedToBasket]
-      )      
+      )
+      cqrs.subscribe(
+        ->(event) do
+          cqrs.run(
+            Shipping::RemoveItemFromShipmentPickingList.new(
+              order_id: event.data.fetch(:order_id),
+              product_id: event.data.fetch(:product_id)
+            )
+          )
+        end,
+        [Pricing::ItemRemovedFromBasket]
+      )           
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR 

- Adds the Shipping module / BC structure / folders and files 
- Implement the orchestration of the `ItemAddedToShipmentPickingList` and `ItemRemovedFromShipmentPickingList` events. 
- These events are the starting point for the following outlined shipping process / flow

![shipping_flow](https://user-images.githubusercontent.com/413133/135725944-87e004f9-7761-4f72-a755-3d68cd448ede.png)

### Notes

- I plan to implement all events outlined in the shipping process above in follow-up PRs
- At this point Shipping BC treas all type of products - physical and digital - the same, what's not ideal because it creates shipments for digital products. The plan is to solve this in a follow-up PR.