### PR TITLE
Unify discount range

### DIFF
--- a/ecommerce/pricing/test/pricing_test.rb
+++ b/ecommerce/pricing/test/pricing_test.rb
@@ -71,6 +71,28 @@ module Pricing
       end
     end
 
+    def test_calculates_total_value_with_100_discount
+      product_1_id = SecureRandom.uuid
+      set_price(product_1_id, 20)
+      order_id = SecureRandom.uuid
+      add_item(order_id, product_1_id)
+      stream = "Pricing::Order$#{order_id}"
+      assert_events(
+        stream,
+        OrderTotalValueCalculated.new(
+          data: {
+            order_id: order_id,
+            discounted_amount: 0,
+            total_amount: 20
+          }
+        )
+      ) do
+        run_command(
+          Pricing::SetPercentageDiscount.new(order_id: order_id, amount: 100)
+        )
+      end
+    end
+
     def test_setting_discounts_twice_not_possible_because_we_want_explicit_discount_change_command
       product_1_id = SecureRandom.uuid
       set_price(product_1_id, 20)

--- a/infra/lib/infra/types.rb
+++ b/infra/lib/infra/types.rb
@@ -14,7 +14,7 @@ module Infra
       Types::Strict::String.constrained(format: /\A\d{4}\/\d{2}\/\d+\z/i)
     Price = Types::Coercible::Decimal.constrained(gt: 0)
     Value = Types::Coercible::Decimal
-    PercentageDiscount = Types::Coercible::Decimal.constrained(gt: 0, lt: 100)
+    PercentageDiscount = Types::Coercible::Decimal.constrained(gt: 0, lteq: 100)
     UUIDQuantityHash = Types::Hash.map(UUID, Types::Strict::Integer.constrained(gt: 0))
 
     class VatRate < Dry::Struct

--- a/rails_application/Gemfile.lock
+++ b/rails_application/Gemfile.lock
@@ -262,6 +262,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-linux
 


### PR DESCRIPTION
I noticed that there is a bit of inconsistency in the percentage discount ranges.
Please take a look:
https://github.com/RailsEventStore/ecommerce/blob/da19fe55addf24682630497cc1b2dd5ba19f40c4/ecommerce/pricing/lib/pricing/discounts.rb#L7-L12

here we raise the exception if `value > 100` (so it allows to use `100%` discount), but the  `PercentageDiscount` constraining rule had defined `(gt: 0, lt: 100)` - which means that validation would raise error when we set `100%` 🙂 

I hope my insight is correct, but if not feel free to close my PR 😸 