### PR TITLE
Client Panel - see my orders

### DIFF
--- a/rails_application/app/controllers/client_orders_controller.rb
+++ b/rails_application/app/controllers/client_orders_controller.rb
@@ -1,0 +1,14 @@
+class ClientOrdersController < ApplicationController
+  def index
+    @clients = ClientOrders::Client.all
+  end
+
+  def show
+    @client = ClientOrders::Client.find_by(uid: params[:id])
+    @client_orders = ClientOrders::Order.where(client_uid: params[:id])
+  end
+
+  def login
+    redirect_to action: 'show', id: params[:client_id]
+  end
+end

--- a/rails_application/app/read_models/client_orders/configuration.rb
+++ b/rails_application/app/read_models/client_orders/configuration.rb
@@ -1,0 +1,95 @@
+module ClientOrders
+  class Client < ApplicationRecord
+    self.table_name = "clients"
+
+    has_many :orders,
+             -> { client(id: :asc) },
+             class_name: "ClientOrders::Order",
+             foreign_key: :client_uid,
+             primary_key: :uid
+  end
+
+  class Order < ApplicationRecord
+    self.table_name = "client_orders"
+  end
+
+  class Configuration
+    def call(cqrs)
+      @cqrs = cqrs
+
+      subscribe_and_link_to_stream(
+        ->(event) { create_client(event) },
+        [Crm::CustomerRegistered]
+      )
+
+      subscribe_and_link_to_stream(
+        ->(event) { mark_as_submitted(event) },
+        [Ordering::OrderSubmitted]
+      )
+
+      subscribe_and_link_to_stream(
+        ->(event) { change_order_state(event, "Expired") },
+        [Ordering::OrderExpired]
+      )
+
+      subscribe_and_link_to_stream(
+        ->(event) { change_order_state(event, "Paid") },
+        [Ordering::OrderPaid]
+      )
+
+      subscribe_and_link_to_stream(
+        ->(event) { change_order_state(event, "Cancelled") },
+        [Ordering::OrderCancelled]
+      )
+    end
+
+    private
+
+    def subscribe_and_link_to_stream(handler, events)
+      link_and_handle = ->(event) do
+        link_to_stream(event)
+        handler.call(event)
+      end
+      subscribe(link_and_handle, events)
+    end
+
+    def subscribe(handler, events)
+      @cqrs.subscribe(handler, events)
+    end
+
+    def link_to_stream(event)
+      @cqrs.link_event_to_stream(event, "ClientOrders$all")
+    end
+
+    def create_client(event)
+      Client.create(
+        uid: event.data.fetch(:customer_id),
+        name: event.data.fetch(:name)
+      )
+    end
+
+    def mark_as_submitted(event)
+      order = Order.find_or_create_by(order_uid: event.data.fetch(:order_id))
+      order.number = event.data.fetch(:order_number)
+      order.client_uid = event.data.fetch(:customer_id)
+      order.state = "Submitted"
+      order.save!
+    end
+
+    def change_order_state(event, new_state)
+      with_order(event) { |order| order.state = new_state }
+    end
+
+    def with_order(event)
+      order = Order
+                .find_by(order_uid: event.data.fetch(:order_id))
+      unless order.nil?
+        order
+          .tap do |order|
+          yield(order)
+          order.save!
+        end
+      end
+    end
+  end
+end

--- a/rails_application/app/views/application/_top_navigation.html.erb
+++ b/rails_application/app/views/application/_top_navigation.html.erb
@@ -12,6 +12,7 @@
             <%= navigation_link "Orders", orders_path %>
             <%= navigation_link "Products", products_path %>
             <%= navigation_link "Customers", customers_path %>
+            <%= navigation_link "Client", client_path %>
           </div>
         </div>
       </div>

--- a/rails_application/app/views/client_orders/index.html.erb
+++ b/rails_application/app/views/client_orders/index.html.erb
@@ -1,0 +1,13 @@
+  <% content_for(:header) do %>
+  Clients panel
+<% end %>
+
+<%= form_tag({controller: "client_orders", action: "login"}, method: "post", id: "form") do %>
+  <div>
+    <label for="customer" class="block font-bold">
+      Client
+    </label>
+    <%= select_tag(:client_id, options_from_collection_for_select(@clients, :uid, :name), id: "customer", class: "mt-1 focus:ring-blue-500 focus:border-blue-500 block shadow-sm sm:text-sm border-gray-300 rounded-md") %>
+    <%= button_tag('Login', class: "mt-2 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded") %>
+  </div>
+<% end %>

--- a/rails_application/app/views/client_orders/show.html.erb
+++ b/rails_application/app/views/client_orders/show.html.erb
@@ -1,0 +1,34 @@
+<% content_for(:header) do %>
+  <%= @client.name %>
+<% end %>
+
+<% content_for(:actions) do %>
+  <%= secondary_action_button do %>
+    <%= link_to 'Log out', client_path %>
+  <% end %>
+<% end %>
+
+
+<div>
+  <% if @client_orders.count > 0 %>
+  <table class="w-full">
+    <thead>
+    <tr>
+      <th class="text-left py-2">Number</th>
+      <th class="text-right py-2">State</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <% @client_orders.each do |order| %>
+      <tr class="border-t">
+        <td class="py-2"><%= link_to order.number || 'Not submitted', order_path(order.order_uid), class: "text-blue-500 hover:underline" %></td>
+        <td class="py-2 text-right"><%= order.state %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+  <% else %>
+    No orders to display.
+  <% end %>
+</div>

--- a/rails_application/config/routes.rb
+++ b/rails_application/config/routes.rb
@@ -25,6 +25,10 @@ Rails.application.routes.draw do
   end
   resources :customers, only: [:new, :create, :index, :update]
 
+  get "/client", to: "client_orders#index"
+  get "/client/:id", to: "client_orders#show"
+  post "/client", to: "client_orders#login"
+
   match("architecture", to: "architecture#index", via: :get)
   mount RailsEventStore::Browser => "/res"
 end

--- a/rails_application/db/migrate/20220219130650_create_clients.rb
+++ b/rails_application/db/migrate/20220219130650_create_clients.rb
@@ -1,0 +1,10 @@
+class CreateClients < ActiveRecord::Migration[6.1]
+  def change
+    create_table :clients do |t|
+      t.uuid :uid
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/rails_application/db/migrate/20220219162101_create_client_orders.rb
+++ b/rails_application/db/migrate/20220219162101_create_client_orders.rb
@@ -1,0 +1,12 @@
+class CreateClientOrders < ActiveRecord::Migration[6.1]
+  def change
+    create_table :client_orders do |t|
+      t.uuid :client_uid
+      t.string :number
+      t.uuid :order_uid
+      t.string :state
+
+      t.timestamps
+    end
+  end
+end

--- a/rails_application/db/schema.rb
+++ b/rails_application/db/schema.rb
@@ -10,11 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_21_131334) do
+ActiveRecord::Schema.define(version: 2022_02_19_162101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "client_orders", force: :cascade do |t|
+    t.uuid "client_uid"
+    t.string "number"
+    t.uuid "order_uid"
+    t.string "state"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "clients", force: :cascade do |t|
+    t.uuid "uid"
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "customers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"

--- a/rails_application/lib/configuration.rb
+++ b/rails_application/lib/configuration.rb
@@ -8,6 +8,7 @@ class Configuration
     enable_products_read_model(cqrs)
     enable_customers_read_model(cqrs)
     enable_invoices_read_model(cqrs)
+    enable_client_orders_read_model(cqrs)
 
     Ecommerce::Configuration.new(
       number_generator: Rails.configuration.number_generator,
@@ -43,5 +44,9 @@ class Configuration
 
   def enable_invoices_read_model(cqrs)
     Invoices::Configuration.new.call(cqrs)
+  end
+
+  def enable_client_orders_read_model(cqrs)
+    ClientOrders::Configuration.new.call(cqrs)
   end
 end

--- a/rails_application/test/client_orders/customer_registered_test.rb
+++ b/rails_application/test/client_orders/customer_registered_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+module ClientOrders
+  class CustomerRegisteredTest < InMemoryTestCase
+    cover "Clients"
+
+    def setup
+      super
+      Client.destroy_all
+    end
+
+    def test_customer_registered
+      event_store = Rails.configuration.event_store
+
+      customer_id = SecureRandom.uuid
+
+      event_store.publish(Crm::CustomerRegistered.new(
+        data: {
+          customer_id: customer_id,
+          name: "John Doe"
+        }
+      ))
+
+      client = Client.find_by(uid: customer_id)
+      assert_not_nil(client)
+      assert_equal("John Doe", client.name)
+      assert_equal(customer_id, client.uid)
+    end
+
+  end
+end

--- a/rails_application/test/client_orders/order_cancelled_test.rb
+++ b/rails_application/test/client_orders/order_cancelled_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+module ClientOrders
+  class OrderCancelledTest < InMemoryTestCase
+    cover "Clients"
+
+    def setup
+      super
+      Client.destroy_all
+      Order.destroy_all
+    end
+
+    def test_order_paid
+      event_store = Rails.configuration.event_store
+      customer_id = SecureRandom.uuid
+      order_id = SecureRandom.uuid
+      order_number = Ordering::FakeNumberGenerator::FAKE_NUMBER
+
+      event_store.publish(Crm::CustomerRegistered.new(
+        data: {
+          customer_id: customer_id,
+          name: "John Doe"
+        }
+      ))
+
+      event_store.publish(
+        Ordering::OrderSubmitted.new(
+          data: {
+            order_id: order_id,
+            order_number: order_number,
+            customer_id: customer_id,
+            order_lines: { }
+          }
+        )
+      )
+
+      event_store.publish(
+        Ordering::OrderCancelled.new(
+          data: {
+            order_id: order_id
+          }
+        )
+      )
+
+      orders = Order.all
+      assert_not_empty(orders)
+      assert_equal(1, orders.count)
+      assert_equal(order_number, orders.first.number)
+      assert_equal("Cancelled",  orders.first.state)
+    end
+  end
+end

--- a/rails_application/test/client_orders/order_expired_test.rb
+++ b/rails_application/test/client_orders/order_expired_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+module ClientOrders
+  class OrderExpiredTest < InMemoryTestCase
+    cover "Clients"
+
+    def setup
+      super
+      Client.destroy_all
+      Order.destroy_all
+    end
+
+    def test_order_expired
+      event_store = Rails.configuration.event_store
+      customer_id = SecureRandom.uuid
+      order_id = SecureRandom.uuid
+      order_number = Ordering::FakeNumberGenerator::FAKE_NUMBER
+
+      event_store.publish(Crm::CustomerRegistered.new(
+        data: {
+          customer_id: customer_id,
+          name: "John Doe"
+        }
+      ))
+
+      event_store.publish(
+        Ordering::OrderSubmitted.new(
+          data: {
+            order_id: order_id,
+            order_number: order_number,
+            customer_id: customer_id,
+            order_lines: { }
+          }
+        )
+      )
+
+      event_store.publish(
+        Ordering::OrderExpired.new(
+          data: {
+            order_id: order_id
+          }
+        )
+      )
+
+      orders = Order.all
+      assert_not_empty(orders)
+      assert_equal(1, orders.count)
+      assert_equal(order_number, orders.first.number)
+      assert_equal("Expired",  orders.first.state)
+    end
+  end
+end

--- a/rails_application/test/client_orders/order_paid_test.rb
+++ b/rails_application/test/client_orders/order_paid_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+module ClientOrders
+  class OrderPaidTest < InMemoryTestCase
+    cover "Clients"
+
+    def setup
+      super
+      Client.destroy_all
+      Order.destroy_all
+    end
+
+    def test_order_paid
+      event_store = Rails.configuration.event_store
+      customer_id = SecureRandom.uuid
+      order_id = SecureRandom.uuid
+      order_number = Ordering::FakeNumberGenerator::FAKE_NUMBER
+
+      event_store.publish(Crm::CustomerRegistered.new(
+        data: {
+          customer_id: customer_id,
+          name: "John Doe"
+        }
+      ))
+
+      event_store.publish(
+        Ordering::OrderSubmitted.new(
+          data: {
+            order_id: order_id,
+            order_number: order_number,
+            customer_id: customer_id,
+            order_lines: { }
+          }
+        )
+      )
+
+      event_store.publish(
+        Ordering::OrderPaid.new(
+          data: {
+            order_id: order_id
+          }
+        )
+      )
+
+      orders = Order.all
+      assert_not_empty(orders)
+      assert_equal(1, orders.count)
+      assert_equal(order_number, orders.first.number)
+      assert_equal("Paid",  orders.first.state)
+    end
+  end
+end

--- a/rails_application/test/client_orders/order_submitted_test.rb
+++ b/rails_application/test/client_orders/order_submitted_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+module ClientOrders
+  class OrderSubmittedTest < InMemoryTestCase
+    cover "Clients"
+
+    def setup
+      super
+      Client.destroy_all
+      Order.destroy_all
+    end
+
+    def test_order_submitted
+      event_store = Rails.configuration.event_store
+      customer_id = SecureRandom.uuid
+      order_id = SecureRandom.uuid
+      order_number = Ordering::FakeNumberGenerator::FAKE_NUMBER
+
+      event_store.publish(Crm::CustomerRegistered.new(
+        data: {
+          customer_id: customer_id,
+          name: "John Doe"
+        }
+      ))
+
+      event_store.publish(
+        Ordering::OrderSubmitted.new(
+          data: {
+            order_id: order_id,
+            order_number: order_number,
+            customer_id: customer_id,
+            order_lines: { }
+          }
+        )
+      )
+
+      orders = Order.all
+      assert_not_empty(orders)
+      assert_equal(1, orders.count)
+      assert_equal(order_number, orders.first.number)
+      assert_equal("Submitted",  orders.first.state)
+    end
+  end
+end


### PR DESCRIPTION
* Introduced a view that presents orders of selected (mocked-logged in) client under /client path. Since we currently lack authentication, you can "login" as any client and see the orders.

Currently, only orders that are at least submitted are visible to the client. That's because there's no correlation between the client and the draft order.

The next step would be
* adding real authentication and removing the possibility to see other client's orders,
* correlating client with the draft order