### PR TITLE
fix exception: uninitialized constant

### DIFF
--- a/rails_application/app/controllers/products_controller.rb
+++ b/rails_application/app/controllers/products_controller.rb
@@ -23,7 +23,7 @@ class ProductsController < ApplicationController
     rescue ProductCatalog::AlreadyRegistered
       flash[:notice] = "Product was already registered"
       render "new"
-    rescue Invoicing::Product::VatRateNotApplicable
+    rescue Taxes::Product::VatRateNotApplicable
       flash[:notice] = "Selected VAT rate not applicable"
       render "new"
     else


### PR DESCRIPTION
When posted wrong vat code: NameError (uninitialized constant Invoicing::Product::VatRateNotApplicable)
But still not working because of https://github.com/RailsEventStore/ecommerce/blob/master/rails_application/app/controllers/products_controller.rb#L45 and exception: [Infra::Types::VatRate.new] :code is missing in Hash input

;)