### PR TITLE
Do not allow removal of an item if its quantity is zero

### DIFF
--- a/ecommerce/ordering/lib/ordering/order.rb
+++ b/ecommerce/ordering/lib/ordering/order.rb
@@ -7,6 +7,7 @@ module Ordering
     NotSubmitted = Class.new(StandardError)
     OrderHasExpired = Class.new(StandardError)
     MissingCustomer = Class.new(StandardError)
+    CannotRemoveZeroQuantityItem = Class.new(StandardError)
 
     def initialize(id)
       @id = id
@@ -51,6 +52,7 @@ module Ordering
 
     def remove_item(product_id)
       raise AlreadySubmitted unless @state.equal?(:draft)
+      raise CannotRemoveZeroQuantityItem if @basket.quantity(product_id).zero?
       apply ItemRemovedFromBasket.new(data: { order_id: @id, product_id: product_id })
     end
 

--- a/ecommerce/ordering/test/remove_item_from_basket_test.rb
+++ b/ecommerce/ordering/test/remove_item_from_basket_test.rb
@@ -49,5 +49,14 @@ module Ordering
         act(RemoveItemFromBasket.new(order_id: aggregate_id, product_id: product_id))
       end
     end
+
+    def test_no_remove_allowed_if_item_quantity_eq_zero
+      aggregate_id = SecureRandom.uuid
+      product_id = SecureRandom.uuid
+
+      assert_raises(Order::CannotRemoveZeroQuantityItem) do
+        act(RemoveItemFromBasket.new(order_id: aggregate_id, product_id: product_id))
+      end
+    end
   end
 end

--- a/rails_application/app/controllers/orders_controller.rb
+++ b/rails_application/app/controllers/orders_controller.rb
@@ -78,6 +78,9 @@ class OrdersController < ApplicationController
       )
     )
     redirect_to edit_order_path(params[:id])
+  rescue Ordering::Order::CannotRemoveZeroQuantityItem
+    redirect_to edit_order_path(params[:id]),
+                alert: "Cannot remove the product with 0 quantity"
   end
 
   def create


### PR DESCRIPTION
I noticed an issue with removing items with 0 quantity, so I've just tried to fix it.

When a user tried to remove an item with 0 quantity, it would throw an exception:
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/3011019/159348402-89fa17cb-7ce8-49d8-aa4f-8d2bf2d0444e.png">

WDYT? 🙂 