### PR TITLE
Fix path to the Order history path

### DIFF
--- a/rails_application/app/helpers/application_helper.rb
+++ b/rails_application/app/helpers/application_helper.rb
@@ -52,7 +52,7 @@ module ApplicationHelper
   end
 
   def order_history_link(id, options = {})
-    stream_browser_link("History", "Crm::Order$#{id}", options)
+    stream_browser_link("History", "Ordering::Order$#{id}", options)
   end
 
   def current_link_to(label, path, **kwargs)

--- a/rails_application/app/helpers/application_helper.rb
+++ b/rails_application/app/helpers/application_helper.rb
@@ -52,7 +52,7 @@ module ApplicationHelper
   end
 
   def order_history_link(id, options = {})
-    stream_browser_link("History", "Orders$#{id}", options)
+    stream_browser_link("History", "Crm::Order$#{id}", options)
   end
 
   def current_link_to(label, path, **kwargs)


### PR DESCRIPTION
Currently generated path is wrong, it always shows an empty page. It's because the stream name is `Crm::Order$<id>`, not `Orders$<id>`.

Before:

<img width="1493" alt="image" src="https://user-images.githubusercontent.com/73225579/169906604-f8366caa-1e0e-4bff-859a-8db0506edb8a.png">

After:

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/12682792/169911674-843d9a61-783d-4d49-98fb-1eacfd5d0f6d.png">

