### PR TITLE
Price from prices calendar

### DIFF
--- a/ecommerce/pricing/lib/pricing/events.rb
+++ b/ecommerce/pricing/lib/pricing/events.rb
@@ -11,12 +11,6 @@ module Pricing
     attribute :price, Infra::Types::Price
   end
 
-  class FuturePriceSet < Infra::Event
-    attribute :product_id, Infra::Types::UUID
-    attribute :price, Infra::Types::Price
-    attribute :valid_since, Infra::Types::Params::DateTime
-  end
-
   class TimePromotionCreated < Infra::Event
     attribute :time_promotion_id, Infra::Types::UUID
     attribute? :discount, Infra::Types::PercentageDiscount

--- a/ecommerce/pricing/lib/pricing/pricing_catalog.rb
+++ b/ecommerce/pricing/lib/pricing/pricing_catalog.rb
@@ -42,6 +42,7 @@ module Pricing
       @event_store
         .read
         .of_type(PriceSet)
+        .as_of
         .to_a
         .filter { |e| e.data.fetch(:product_id).eql?(product_id) }
     end

--- a/ecommerce/pricing/lib/pricing/pricing_catalog.rb
+++ b/ecommerce/pricing/lib/pricing/pricing_catalog.rb
@@ -23,14 +23,14 @@ module Pricing
       [to_calendar_entry(current_price(product_id))] + future_prices_catalog_by_product_id(product_id)
     end
 
+    private
+
     def future_prices_catalog_by_product_id(product_id)
       read_prices_set(product_id)
         .select(&method(:future_prices))
         .map(&method(:to_calendar_entry))
         .sort_by { |entry| entry.fetch(:valid_since) }
     end
-
-    private
 
     def current_price(product_id)
       read_prices_set(product_id)

--- a/ecommerce/pricing/lib/pricing/pricing_catalog.rb
+++ b/ecommerce/pricing/lib/pricing/pricing_catalog.rb
@@ -20,7 +20,7 @@ module Pricing
     end
 
     def current_prices_catalog_by_product_id(product_id)
-      [to_calendar_entry(current_price(product_id))] + future_prices_catalog_by_product_id(product_id)
+      ([current_price(product_id)] + future_prices_catalog_by_product_id(product_id)).map(&method(:to_calendar_entry))
     end
 
     private
@@ -28,8 +28,6 @@ module Pricing
     def future_prices_catalog_by_product_id(product_id)
       read_prices_set(product_id)
         .select(&method(:future_prices))
-        .map(&method(:to_calendar_entry))
-        .sort_by { |entry| entry.fetch(:valid_since) }
     end
 
     def current_price(product_id)

--- a/ecommerce/pricing/lib/pricing/product.rb
+++ b/ecommerce/pricing/lib/pricing/product.rb
@@ -10,14 +10,8 @@ module Pricing
       apply(PriceSet.new(data: { product_id: @id, price: price }))
     end
 
-    def set_future_price(price, valid_at)
-      apply(FuturePriceSet.new(data: { product_id: @id, price: price, valid_since: valid_at }))
-    end
-
     private
 
     on(PriceSet) { |_| }
-
-    on(FuturePriceSet) { |_| }
   end
 end

--- a/ecommerce/pricing/lib/pricing/services.rb
+++ b/ecommerce/pricing/lib/pricing/services.rb
@@ -74,7 +74,6 @@ module Pricing
       @event_store.with_metadata({ valid_at: cmd.valid_since }) do
         @repository.with_aggregate(Product, cmd.product_id) do |product|
           product.set_price(cmd.price)
-          product.set_future_price(cmd.price, cmd.valid_since)
         end
       end
     end

--- a/ecommerce/pricing/test/future_prices_test.rb
+++ b/ecommerce/pricing/test/future_prices_test.rb
@@ -77,7 +77,11 @@ module Pricing
           BigDecimal(50),
           BigDecimal(30)
         ], pricing_catalog.current_prices_catalog_by_product_id(product_id).map { |entry| entry[:price] }
-
+        assert_equal [
+          future_date_timestamp_1.to_s,
+          future_date_timestamp_2.to_s,
+          future_date_timestamp_3.to_s,
+        ], pricing_catalog.current_prices_catalog_by_product_id(product_id).map { |entry| entry[:valid_since].to_s }
         assert_equal BigDecimal(40), pricing_catalog.price_by_product_id(product_id)
       end
 
@@ -86,7 +90,10 @@ module Pricing
           BigDecimal(50),
           BigDecimal(30)
         ], pricing_catalog.current_prices_catalog_by_product_id(product_id).map { |entry| entry[:price] }
-
+        assert_equal [
+          future_date_timestamp_2.to_s,
+          future_date_timestamp_3.to_s,
+        ], pricing_catalog.current_prices_catalog_by_product_id(product_id).map { |entry| entry[:valid_since].to_s }
         assert_equal BigDecimal(50), pricing_catalog.price_by_product_id(product_id)
       end
 
@@ -94,6 +101,9 @@ module Pricing
       pricing_catalog = PricingCatalog.new(event_store)
       Timecop.travel(future_date_timestamp_3 + 1) do
         assert_equal [BigDecimal(30)], pricing_catalog.current_prices_catalog_by_product_id(product_id).map { |entry| entry[:price] }
+        assert_equal [
+          future_date_timestamp_3.to_s
+        ], pricing_catalog.current_prices_catalog_by_product_id(product_id).map { |entry| entry[:valid_since].to_s }
         assert_equal BigDecimal(30), pricing_catalog.price_by_product_id(product_id)
       end
     end

--- a/ecommerce/pricing/test/product_test.rb
+++ b/ecommerce/pricing/test/product_test.rb
@@ -17,7 +17,6 @@ module Pricing
 
       future_price_set = [
         PriceSet.new(data: { product_id: product_id, price: price }),
-        FuturePriceSet.new(data: { product_id: product_id, price: price, valid_since: valid_since })
       ]
 
       assert_events("Pricing::Product$#{product_id}", *future_price_set) do

--- a/rails_application/app/controllers/products_controller.rb
+++ b/rails_application/app/controllers/products_controller.rb
@@ -41,11 +41,11 @@ class ProductsController < ApplicationController
     end
     if params[:future_prices].present?
       params[:future_prices].each do |future_price|
-          set_future_product_price(
-            params[:product_id],
-            future_price["price"],
-            future_price["start_time"]
-          )
+        set_future_product_price(
+          params[:product_id],
+          future_price["price"],
+          Time.parse(future_price["start_time"]).in_time_zone("UTC").to_s
+        )
       end
     end
     redirect_to products_path, notice: "Price was successfully updated"

--- a/rails_application/app/controllers/products_controller.rb
+++ b/rails_application/app/controllers/products_controller.rb
@@ -44,7 +44,7 @@ class ProductsController < ApplicationController
         set_future_product_price(
           params[:product_id],
           future_price["price"],
-          Time.parse(future_price["start_time"]).in_time_zone("UTC").to_s
+          Time.parse(future_price["start_time"]).utc.to_s
         )
       end
     end

--- a/rails_application/app/read_models/products/configuration.rb
+++ b/rails_application/app/read_models/products/configuration.rb
@@ -5,7 +5,7 @@ module Products
 
     def current_prices_calendar
       return [] unless super
-      super.map { |entry| entry.merge(valid_since: time_of(entry).to_time) }
+      super.map(&method(:parese_date))
     end
 
     def future_prices_calendar

--- a/rails_application/app/read_models/products/configuration.rb
+++ b/rails_application/app/read_models/products/configuration.rb
@@ -29,7 +29,7 @@ module Products
 
     def parese_calendar_entry(entry)
       {
-        valid_since:  Time.zone.parse(time_of(entry)),
+        valid_since:  Time.parse(time_of(entry)).in_time_zone(Time.now.zone),
         price: BigDecimal(entry[:price])
       }
     end

--- a/rails_application/app/read_models/products/configuration.rb
+++ b/rails_application/app/read_models/products/configuration.rb
@@ -13,16 +13,16 @@ module Products
     end
 
     def price(time = Time.now)
-      price_entry_on(time)[:price]
+      price_on(time)
     end
 
     private
 
-    def price_entry_on(time)
+    def price_on(time)
       current_prices_calendar.each_with_index do |entry, index|
         next_entry = current_prices_calendar[index + 1]
         if time_of(entry) < time && (!next_entry || time_of(next_entry) > time)
-          break entry
+          break entry[:price]
         end
       end
     end

--- a/rails_application/app/read_models/products/configuration.rb
+++ b/rails_application/app/read_models/products/configuration.rb
@@ -5,7 +5,7 @@ module Products
 
     def current_prices_calendar
       return [] unless super
-      super.map(&method(:parese_date))
+      super.map(&method(:parese_calendar_entry))
     end
 
     def future_prices_calendar
@@ -13,7 +13,7 @@ module Products
     end
 
     def price(time = Time.now)
-      BigDecimal(price_entry_on(time)[:price])
+      price_entry_on(time)[:price]
     end
 
     private
@@ -27,8 +27,11 @@ module Products
       end
     end
 
-    def parese_date(entry)
-      entry.merge(valid_since: time_of(entry).to_datetime)
+    def parese_calendar_entry(entry)
+      {
+        valid_since: time_of(entry).to_datetime,
+        price: BigDecimal(entry[:price])
+      }
     end
 
     def time_of(entry)

--- a/rails_application/app/read_models/products/configuration.rb
+++ b/rails_application/app/read_models/products/configuration.rb
@@ -50,7 +50,6 @@ module Products
       @read_model.copy(ProductCatalog::ProductNamed,       :name)
       @read_model.copy(Inventory::StockLevelChanged,       :stock_level)
       @read_model.copy_nested_to_column(Taxes::VatRateSet, :vat_rate, :code, :vat_rate_code)
-      @event_store.subscribe(RefreshFuturePricesCalendar, to: [Pricing::FuturePriceSet])
       @event_store.subscribe(RefreshFuturePricesCalendar, to: [Pricing::PriceSet])
     end
   end

--- a/rails_application/app/read_models/products/configuration.rb
+++ b/rails_application/app/read_models/products/configuration.rb
@@ -29,7 +29,7 @@ module Products
 
     def parese_calendar_entry(entry)
       {
-        valid_since: time_of(entry).to_datetime,
+        valid_since:  Time.zone.parse(time_of(entry)),
         price: BigDecimal(entry[:price])
       }
     end

--- a/rails_application/app/read_models/products/configuration.rb
+++ b/rails_application/app/read_models/products/configuration.rb
@@ -52,7 +52,6 @@ module Products
       @read_model.copy_nested_to_column(Taxes::VatRateSet, :vat_rate, :code, :vat_rate_code)
       @event_store.subscribe(RefreshFuturePricesCalendar, to: [Pricing::FuturePriceSet])
       @event_store.subscribe(RefreshFuturePricesCalendar, to: [Pricing::PriceSet])
-      @event_store.subscribe(SetPrice, to: [Pricing::PriceSet])
     end
   end
 end

--- a/rails_application/app/read_models/products/refresh_future_prices_calendar.rb
+++ b/rails_application/app/read_models/products/refresh_future_prices_calendar.rb
@@ -3,15 +3,15 @@ module Products
     def call(event)
       product_id = event.data.fetch(:product_id)
       product = Product.find(product_id)
-      product.update!(future_prices_calendar: future_prices_calendar(product_id))
+      product.update!(current_prices_calendar: current_prices_calendar(product_id))
     end
 
     private
 
-    def future_prices_calendar(product_id)
+    def current_prices_calendar(product_id)
       Pricing::PricingCatalog
         .new(event_store)
-        .future_prices_catalog_by_product_id(product_id)
+        .current_prices_catalog_by_product_id(product_id)
         .map(&method(:values_to_string))
     end
 

--- a/rails_application/app/views/products/_future_price.html.erb
+++ b/rails_application/app/views/products/_future_price.html.erb
@@ -5,7 +5,7 @@
     <label for="start_time" class="inline font-bold p-2">
       Start time:
       <%= datetime_field_tag :start_time, nil,
-        value: valid_since&.to_datetime&.strftime('%Y-%m-%dT%H:%M'),
+        value: valid_since&.strftime('%Y-%m-%dT%H:%M'),
         disabled: disabled,
         id: "start_time",
         name: "[future_prices][][start_time]",

--- a/rails_application/db/migrate/20221215214459_rename_future_prices_calendar_future_prices_calendar.rb
+++ b/rails_application/db/migrate/20221215214459_rename_future_prices_calendar_future_prices_calendar.rb
@@ -1,0 +1,5 @@
+class RenameFuturePricesCalendarFuturePricesCalendar < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :products, :future_prices_calendar, :current_prices_calendar
+  end
+end

--- a/rails_application/db/schema.rb
+++ b/rails_application/db/schema.rb
@@ -159,7 +159,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_16_115301) do
     t.integer "stock_level"
     t.datetime "registered_at", precision: nil
     t.string "vat_rate_code"
-    t.text "future_prices_calendar"
+    t.text "current_prices_calendar"
   end
 
   create_table "public_offer_products", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/rails_application/scripts/rebuild_prices.rb
+++ b/rails_application/scripts/rebuild_prices.rb
@@ -1,0 +1,8 @@
+event_store = Rails.configuration.event_store
+pricing_catalog = Pricing::PricingCatalog.new(event_store)
+Products::Product.all.each do |product|
+  calendar = pricing_catalog.current_prices_catalog_by_product_id(product.id)
+    .map { |entry| entry.transform_values(&:to_s) }
+  product.update(current_prices_calendar: calendar)
+end
+

--- a/rails_application/test/products/update_future_prices_calenar_test.rb
+++ b/rails_application/test/products/update_future_prices_calenar_test.rb
@@ -14,8 +14,8 @@ module Products
       event_store.publish(set_price)
 
       date_1 = Time.now + 3600
-      date_2 = Time.current + 7200
-      date_3 = Time.current + 10800
+      date_2 = Time.now + 7200
+      date_3 = Time.now + 10800
 
 
       product = Product.find_by_id(product_id)

--- a/rails_application/test/products/update_future_prices_calenar_test.rb
+++ b/rails_application/test/products/update_future_prices_calenar_test.rb
@@ -27,11 +27,11 @@ module Products
 
       product.reload
       assert_equal 3, product.future_prices_calendar.length
-      assert_equal "1.0", product.future_prices_calendar[0][:price]
+      assert_equal BigDecimal("1.0"), product.future_prices_calendar[0][:price]
       assert_equal date_1.to_s, product.future_prices_calendar[0][:valid_since].to_datetime.to_s
-      assert_equal "2.0", product.future_prices_calendar[1][:price]
+      assert_equal BigDecimal("2.0"), product.future_prices_calendar[1][:price]
       assert_equal date_2.to_s, product.future_prices_calendar[1][:valid_since].to_datetime.to_s
-      assert_equal "12.01", product.future_prices_calendar[2][:price]
+      assert_equal BigDecimal("12.01"), product.future_prices_calendar[2][:price]
       assert_equal date_3.to_s, product.future_prices_calendar[2][:valid_since].to_datetime.to_s
     end
 


### PR DESCRIPTION
This PR fixes misconception of future_prices column.
- It replaces it with current prices column, from which we take the current price based on time.
- We store now the price `valid_since` attribute  in UTC time
- removed obsolete `FuturePriceSet` event
The adding of new future prices should work correctly now

Planned next steps:
- remove price column from Product read model
- refactor: introduce `PricingCatalog::Entry`
- allow to remove not saved future price entry
- update product with no reload
- make future prices editable