### PR TITLE
Omnibus directive implementation

### DIFF
--- a/ecommerce/processes/test/test_helper.rb
+++ b/ecommerce/processes/test/test_helper.rb
@@ -1,6 +1,7 @@
 require "minitest/autorun"
 require "mutant/minitest/coverage"
 require "infra"
+require "active_support/all"
 
 require_relative "../lib/processes"
 

--- a/ecommerce/processes/test/test_helper.rb
+++ b/ecommerce/processes/test/test_helper.rb
@@ -1,7 +1,6 @@
 require "minitest/autorun"
 require "mutant/minitest/coverage"
 require "infra"
-require "active_support/all"
 
 require_relative "../lib/processes"
 

--- a/rails_application/Gemfile
+++ b/rails_application/Gemfile
@@ -32,6 +32,7 @@ end
 
 group :test do
   eval_gemfile "../infra/Gemfile.test"
+  gem "timecop"
 end
 
 gem "infra", path: "../infra"

--- a/rails_application/Gemfile.lock
+++ b/rails_application/Gemfile.lock
@@ -287,6 +287,7 @@ GEM
     tailwindcss-rails (2.0.14-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.2.1)
+    timecop (0.9.6)
     timeout (0.3.0)
     turbo-rails (1.3.0)
       actionpack (>= 6.0.0)
@@ -334,8 +335,9 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   tailwindcss-rails
+  timecop
   turbo-rails
   tzinfo-data
 
 BUNDLED WITH
-   2.3.14
+   2.3.18

--- a/rails_application/app/read_models/client_orders/configuration.rb
+++ b/rails_application/app/read_models/client_orders/configuration.rb
@@ -112,10 +112,6 @@ module ClientOrders
     end
   end
 
-  class Product < ApplicationRecord
-    self.table_name = "client_order_products"
-  end
-
   class Configuration
     def call(event_store)
       event_store.subscribe(ExpireOrder, to: [Ordering::OrderExpired])

--- a/rails_application/app/read_models/client_orders/configuration.rb
+++ b/rails_application/app/read_models/client_orders/configuration.rb
@@ -130,6 +130,7 @@ module ClientOrders
 
       event_store.subscribe(ChangeProductName, to: [ProductCatalog::ProductNamed])
       event_store.subscribe(ChangeProductPrice, to: [Pricing::PriceSet])
+      event_store.subscribe(RegisterLowestPrice, to: [Pricing::PriceSet])
       event_store.subscribe(RegisterProduct, to: [ProductCatalog::ProductRegistered])
       event_store.subscribe(UpdateDiscount, to: [Pricing::PercentageDiscountSet, Pricing::PercentageDiscountChanged])
       event_store.subscribe(ResetDiscount, to: [Pricing::PercentageDiscountReset])

--- a/rails_application/app/read_models/client_orders/product.rb
+++ b/rails_application/app/read_models/client_orders/product.rb
@@ -3,7 +3,7 @@ module ClientOrders
     self.table_name = "client_order_products"
 
     def lowest_recent_price_lower_from_current?
-      lowest_recent_price && lowest_recent_price < price
+      lowest_recent_price < price
     end
   end
 end

--- a/rails_application/app/read_models/client_orders/product.rb
+++ b/rails_application/app/read_models/client_orders/product.rb
@@ -1,0 +1,9 @@
+module ClientOrders
+  class Product < ApplicationRecord
+    self.table_name = "client_order_products"
+
+    def lowest_recent_price_lower_from_current?
+      lowest_recent_price && lowest_recent_price < price
+    end
+  end
+end

--- a/rails_application/app/read_models/client_orders/register_lowest_price.rb
+++ b/rails_application/app/read_models/client_orders/register_lowest_price.rb
@@ -52,8 +52,6 @@ module ClientOrders
         event.event_id,
         stream_name: stream_name(product_id)
       )
-    rescue RubyEventStore::EventDuplicatedInStream => e
-      Rails.log.info("Duplicated event in stream detected: #{e}")
     end
 
     def stream_name(product_id)

--- a/rails_application/app/read_models/client_orders/register_lowest_price.rb
+++ b/rails_application/app/read_models/client_orders/register_lowest_price.rb
@@ -48,7 +48,7 @@ module ClientOrders
     end
 
     def link_to_stream(event, product_id)
-      Rails.configuration.event_store.link(
+      event_store.link(
         event.event_id,
         stream_name: stream_name(product_id)
       )

--- a/rails_application/app/read_models/client_orders/register_lowest_price.rb
+++ b/rails_application/app/read_models/client_orders/register_lowest_price.rb
@@ -1,0 +1,18 @@
+module ClientOrders
+  class RegisterLowestPrice < Infra::EventHandler
+    def call(event)
+      product_id = event.data.fetch(:product_id)
+      product = Product.find(product_id)
+
+      product.update!(lowest_recent_price: lowest_recent_price_for(product_id))
+    end
+
+    private
+
+    def lowest_recent_price_for(product_id)
+      Pricing::PricingCatalog
+        .new(event_store)
+        .lowest_recent_price_by_product_id(product_id)
+    end
+  end
+end

--- a/rails_application/app/read_models/client_orders/register_lowest_price.rb
+++ b/rails_application/app/read_models/client_orders/register_lowest_price.rb
@@ -2,7 +2,7 @@ module ClientOrders
   class RegisterLowestPrice < Infra::EventHandler
     def call(event)
       product_id = event.data.fetch(:product_id)
-      product = Product.find(product_id)
+      product = Product.find_by_uid(product_id)
 
       product.update!(lowest_recent_price: lowest_recent_price_for(product_id))
     end

--- a/rails_application/app/read_models/client_orders/register_lowest_price.rb
+++ b/rails_application/app/read_models/client_orders/register_lowest_price.rb
@@ -1,18 +1,63 @@
 module ClientOrders
   class RegisterLowestPrice < Infra::EventHandler
+    RECENT_PERIOD = 30.days
+
     def call(event)
       product_id = event.data.fetch(:product_id)
-      product = Product.find_by_uid(product_id)
 
-      product.update!(lowest_recent_price: lowest_recent_price_for(product_id))
+      link_to_stream(event, product_id)
+
+      lowest_recent_price = lowest_recent_price_for(product_id)
+
+      product = Product.find_by_uid(product_id)
+      product.update!(lowest_recent_price: lowest_recent_price)
     end
 
     private
 
     def lowest_recent_price_for(product_id)
-      Pricing::PricingCatalog
-        .new(event_store)
-        .lowest_recent_price_by_product_id(product_id)
+      price_changes = project_price_changes(product_id)
+      border_event = find_border_event(price_changes)
+      recent_events = price_changes.select { |price_change| recent_event?(price_change) }.push(border_event)
+
+      recent_events.min_by { |price_change| price_change.fetch(:price) }.fetch(:price)
+    end
+
+    def project_price_changes(product_id)
+      RailsEventStore::Projection
+        .from_stream(stream_name(product_id))
+        .init(-> { [] })
+        .when(
+          Pricing::PriceSet,
+          ->(state, event) { state.push({ valid_at: event.valid_at, price: event.data.fetch(:price) }) }
+        )
+        .run(event_store)
+        .sort_by { |price_change| price_change.fetch(:valid_at) }
+    end
+
+    def find_border_event(price_changes)
+      first_in_scope_index = price_changes.find_index { |price_change| recent_event?(price_change) }
+      index = [first_in_scope_index - 1, 0].max
+
+      price_changes.fetch(index)
+    end
+
+    def recent_event?(price_change)
+      valid_at = price_change.fetch(:valid_at)
+      valid_at > RECENT_PERIOD.ago.beginning_of_day && valid_at < Time.now
+    end
+
+    def link_to_stream(event, product_id)
+      Rails.configuration.event_store.link(
+        event.event_id,
+        stream_name: stream_name(product_id)
+      )
+    rescue RubyEventStore::EventDuplicatedInStream => e
+      Rails.log.info("Duplicated event in stream detected: #{e}")
+    end
+
+    def stream_name(product_id)
+      "PricesHistoryReport$#{product_id}"
     end
   end
 end

--- a/rails_application/app/views/client/orders/edit.html.erb
+++ b/rails_application/app/views/client/orders/edit.html.erb
@@ -15,7 +15,12 @@
       <% order_line = @order_lines&.find{|order_line| order_line.product_id == product.uid} %>
       <td class="py-2"><%= product.name %></td>
       <td class="py-2" id="<%= "client_orders_#{product.uid}_product_quantity" %>"><%= order_line.try(&:product_quantity) || 0 %></td>
-      <td class="py-2"><%= number_to_currency(product.price) %></td>
+      <td class="py-2">
+        <%= number_to_currency(product.price) %>
+        <% if product.lowest_recent_price_lower_from_current? %>
+          <span title="<%= "Lowest recent price: #{number_to_currency(product.lowest_recent_price)}" %>">ℹ️</span>
+        <% end %>
+      </td>
       <td class="py-2"  id="<%= "client_orders_#{product.uid}_value" %>"><%= number_to_currency(order_line.try(&:value)) %></td>
       <td class="py-2 text-right">
         <%= button_to "Add", add_item_client_order_path(id: @order_id, product_id: product.uid), class: "hover:underline text-blue-500" %>
@@ -35,4 +40,3 @@
     <%= submit_tag("Create Order", class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded") %>
   </div>
 <% end %>
-

--- a/rails_application/app/views/client/orders/edit.html.erb
+++ b/rails_application/app/views/client/orders/edit.html.erb
@@ -19,8 +19,8 @@
         <%= number_to_currency(product.price) %>
         <% if product.lowest_recent_price_lower_from_current? %>
           <span
-            title="<%= "Lowest recent price: #{number_to_currency(product.lowest_recent_price)}"
-            id="lowest-price-info"%>"
+            title="<%= "Lowest recent price: #{number_to_currency(product.lowest_recent_price)}"%>"
+            id="lowest-price-info-<%= product.uid %>"
           >
             ℹ️
           </span>

--- a/rails_application/app/views/client/orders/edit.html.erb
+++ b/rails_application/app/views/client/orders/edit.html.erb
@@ -18,7 +18,12 @@
       <td class="py-2">
         <%= number_to_currency(product.price) %>
         <% if product.lowest_recent_price_lower_from_current? %>
-          <span title="<%= "Lowest recent price: #{number_to_currency(product.lowest_recent_price)}" %>">ℹ️</span>
+          <span
+            title="<%= "Lowest recent price: #{number_to_currency(product.lowest_recent_price)}"
+            id="lowest-price-info"%>"
+          >
+            ℹ️
+          </span>
         <% end %>
       </td>
       <td class="py-2"  id="<%= "client_orders_#{product.uid}_value" %>"><%= number_to_currency(order_line.try(&:value)) %></td>

--- a/rails_application/db/migrate/20230110235838_add_lowest_recent_price_to_client_order_products.rb
+++ b/rails_application/db/migrate/20230110235838_add_lowest_recent_price_to_client_order_products.rb
@@ -1,5 +1,14 @@
 class AddLowestRecentPriceToClientOrderProducts < ActiveRecord::Migration[7.0]
-  def change
+  def up
     add_column :client_order_products, :lowest_recent_price, :decimal, precision: 8, scale: 2
+
+    execute <<~SQL
+      UPDATE client_order_products
+      SET lowest_recent_price = price;
+    SQL
+  end
+
+  def down
+    remove_column :client_order_products, :lowest_recent_price
   end
 end

--- a/rails_application/db/migrate/20230110235838_add_lowest_recent_price_to_client_order_products.rb
+++ b/rails_application/db/migrate/20230110235838_add_lowest_recent_price_to_client_order_products.rb
@@ -1,0 +1,5 @@
+class AddLowestRecentPriceToClientOrderProducts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :client_order_products, :lowest_recent_price, :decimal, precision: 8, scale: 2
+  end
+end

--- a/rails_application/db/schema.rb
+++ b/rails_application/db/schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_195547) do
     t.uuid "uid", null: false
     t.string "name"
     t.decimal "price", precision: 8, scale: 2
+    t.decimal "lowest_recent_price", precision: 8, scale: 2
   end
 
   create_table "client_orders", force: :cascade do |t|

--- a/rails_application/test/client_orders/product_price_changed_test.rb
+++ b/rails_application/test/client_orders/product_price_changed_test.rb
@@ -14,6 +14,25 @@ module ClientOrders
       assert_equal 50, Product.find_by_uid(unchanged_product_id).price
     end
 
+    def test_registers_lowest_recent_price
+      product_id = prepare_product
+
+      run_command(Pricing::SetPrice.new(product_id: product_id, price: 40))
+
+      assert_equal 40, Product.find_by_uid(product_id).lowest_recent_price
+    end
+
+    def test_keeps_lowest_recent_price
+      product_id = prepare_product
+
+      run_command(Pricing::SetPrice.new(product_id: product_id, price: 100))
+      run_command(Pricing::SetPrice.new(product_id: product_id, price: 20))
+      run_command(Pricing::SetPrice.new(product_id: product_id, price: 50))
+      run_command(Pricing::SetPrice.new(product_id: product_id, price: 70))
+
+      assert_equal 20, Product.find_by_uid(product_id).lowest_recent_price
+    end
+
     def prepare_product
       product_id = SecureRandom.uuid
       run_command(

--- a/rails_application/test/client_orders/product_price_changed_test.rb
+++ b/rails_application/test/client_orders/product_price_changed_test.rb
@@ -69,6 +69,16 @@ module ClientOrders
       assert_equal 35, Product.find_by_uid(product_id).lowest_recent_price
     end
 
+    def test_ignores_other_products
+      product1_id = prepare_product
+      product2_id = prepare_product
+
+      set_price(product1_id, 35)
+      set_price(product2_id, 25)
+
+      assert_equal 35, Product.find_by_uid(product1_id).lowest_recent_price
+    end
+
     private
 
     def prepare_product

--- a/rails_application/test/client_orders/product_price_changed_test.rb
+++ b/rails_application/test/client_orders/product_price_changed_test.rb
@@ -8,7 +8,7 @@ module ClientOrders
       product_id = prepare_product
       unchanged_product_id = prepare_product
 
-      run_command(Pricing::SetPrice.new(product_id: product_id, price: 100))
+      set_price(product_id, 100)
 
       assert_equal 100, Product.find_by_uid(product_id).price
       assert_equal 50, Product.find_by_uid(unchanged_product_id).price
@@ -17,7 +17,7 @@ module ClientOrders
     def test_registers_lowest_recent_price
       product_id = prepare_product
 
-      run_command(Pricing::SetPrice.new(product_id: product_id, price: 40))
+      set_price(product_id, 40)
 
       assert_equal 40, Product.find_by_uid(product_id).lowest_recent_price
     end
@@ -25,13 +25,51 @@ module ClientOrders
     def test_keeps_lowest_recent_price
       product_id = prepare_product
 
-      run_command(Pricing::SetPrice.new(product_id: product_id, price: 100))
-      run_command(Pricing::SetPrice.new(product_id: product_id, price: 20))
-      run_command(Pricing::SetPrice.new(product_id: product_id, price: 50))
-      run_command(Pricing::SetPrice.new(product_id: product_id, price: 70))
+      set_price(product_id, 100)
+      set_price(product_id, 20)
+      set_price(product_id, 50)
+      set_price(product_id, 70)
 
       assert_equal 20, Product.find_by_uid(product_id).lowest_recent_price
     end
+
+    def test_takes_into_account_price_set_before_30_days
+      product_id = prepare_product
+
+      set_price(product_id, 100)
+      set_past_price(product_id, 15, 31.days.ago.beginning_of_day.to_s)
+      set_price(product_id, 50)
+      set_price(product_id, 70)
+
+      assert_equal 15, Product.find_by_uid(product_id).lowest_recent_price
+    end
+
+    def test_ignores_prices_older_than_30_days
+      product_id = prepare_product
+
+      Timecop.freeze(Time.now) do
+        set_past_price(product_id, 20, 31.days.ago.beginning_of_day.to_s)
+        set_past_price(product_id, 25, (30.days.ago.beginning_of_day - 1.second).to_s)
+        set_past_price(product_id, 30, 30.days.ago.beginning_of_day.to_s)
+        set_past_price(product_id, 32, (30.days.ago.beginning_of_day + 1.second).to_s)
+        set_past_price(product_id, 35, 30.days.ago.to_s)
+        set_past_price(product_id, 40, 29.days.ago.beginning_of_day.to_s)
+
+        assert_equal 30, Product.find_by_uid(product_id).lowest_recent_price
+      end
+    end
+
+    def test_ignores_future_prices
+      product_id = prepare_product
+
+      set_past_price(product_id, 45, 2.days.ago.to_s)
+      set_price(product_id, 35)
+      set_future_price(product_id, 11, (Time.now + 2.days).to_s)
+
+      assert_equal 35, Product.find_by_uid(product_id).lowest_recent_price
+    end
+
+    private
 
     def prepare_product
       product_id = SecureRandom.uuid
@@ -50,5 +88,14 @@ module ClientOrders
 
       product_id
     end
+
+    def set_price(product_id, amount)
+      run_command(Pricing::SetPrice.new(product_id: product_id, price: amount))
+    end
+
+    def set_future_price(product_id, amount, valid_since)
+      run_command(Pricing::SetFuturePrice.new(product_id: product_id, price: amount, valid_since: valid_since))
+    end
+    alias set_past_price set_future_price
   end
 end

--- a/rails_application/test/client_orders/product_price_changed_test.rb
+++ b/rails_application/test/client_orders/product_price_changed_test.rb
@@ -75,8 +75,9 @@ module ClientOrders
 
       set_price(product1_id, 35)
       set_price(product2_id, 25)
+      set_price(product1_id, 30)
 
-      assert_equal 35, Product.find_by_uid(product1_id).lowest_recent_price
+      assert_equal 30, Product.find_by_uid(product1_id).lowest_recent_price
     end
 
     private


### PR DESCRIPTION
I'm adding here a simple implementation of the feature proposed with https://github.com/RailsEventStore/ecommerce/issues/223.

### Problem statement

If any special offer is presented to a consumer, the lowest price in last 30 days should be also presented.

### Solution

1. In `ecommerce` this should be done at least whenever any price with discount is presented to the client. However, we could simplify this in the first iteration, by always showing this information if there was any price change lately. 

    Thus, my idea was to add this information as a simple info icon with details about the lowest price in last 30 days on the `client_orders/edit` page, at the time when customer is making an order.

2. On `client_orders/edit` page we're using the `ClientOrder::Product` read model. So I've decided to add a new column to `client_order_products` table called - `lowest_recent_price`. 

    I though about some more descriptive names like `lowest_price_in_30_days`, but in fact the directive is not saying 30 days, but "at least 30 days". So this number of days is not fixed and can be changing.

    I've initialized this column with current values from `price`. Although this is not perfect, because there might have been already some price changes before, I thought that we can always rebuild the read model if necessary running all the events again.

3. The `lowest_recent_price` is updated on every `Pricing::PriceSet` event. There is a new subscriber `ClientOrders::RegisterLowestPrice` which is handling that. 

    ~~However, it is delegating fetching the lowest price in last 30 days to `Pricing::PricingCatalog` module, with new `lowest_recent_price_by_product_id` method.~~ EDIT: `RegisterLowestPrice` is using a dedicated report stream `PricesHistoryReport` to project the lowest price in last 30 days rolling.

4. The `lowest_recent_price_for` method takes all the `Pricing::PriceSet` events from last 30 days plus one event before that (which I called `border_event`) and finds the minimum price in this set. 

    The `border_event` is necessary become we care about the price that was USED in last 30 days before the current price was set, not that was SET in this period.

### Visual QA

https://user-images.githubusercontent.com/12682792/212203416-e2849d06-189b-4640-9de3-f32d2766e9c8.mp4


