### PR TITLE
Combined dependencies PR

### DIFF
--- a/ecommerce/authentication/Gemfile.lock
+++ b/ecommerce/authentication/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       mutant (= 0.10.34)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool

--- a/ecommerce/authentication/Gemfile.lock
+++ b/ecommerce/authentication/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     minitest (5.15.0)
@@ -83,7 +83,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unparser (0.6.0)
       diff-lcs (~> 1.3)

--- a/ecommerce/crm/Gemfile.lock
+++ b/ecommerce/crm/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       mutant (= 0.10.34)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool

--- a/ecommerce/crm/Gemfile.lock
+++ b/ecommerce/crm/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     minitest (5.15.0)
@@ -83,7 +83,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unparser (0.6.0)
       diff-lcs (~> 1.3)

--- a/ecommerce/inventory/Gemfile.lock
+++ b/ecommerce/inventory/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3.1)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    i18n (1.11.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     minitest (5.15.0)
@@ -83,7 +83,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unparser (0.6.0)
       diff-lcs (~> 1.3)

--- a/ecommerce/inventory/Gemfile.lock
+++ b/ecommerce/inventory/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       mutant (= 0.10.34)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool

--- a/ecommerce/invoicing/Gemfile.lock
+++ b/ecommerce/invoicing/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       mutant (= 0.10.34)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool

--- a/ecommerce/invoicing/Gemfile.lock
+++ b/ecommerce/invoicing/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     minitest (5.15.0)
@@ -83,7 +83,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unparser (0.6.0)
       diff-lcs (~> 1.3)

--- a/ecommerce/ordering/Gemfile.lock
+++ b/ecommerce/ordering/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       mutant (= 0.10.34)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool

--- a/ecommerce/ordering/Gemfile.lock
+++ b/ecommerce/ordering/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     minitest (5.15.0)
@@ -83,7 +83,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unparser (0.6.0)
       diff-lcs (~> 1.3)

--- a/ecommerce/payments/Gemfile.lock
+++ b/ecommerce/payments/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       mutant (= 0.10.34)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool

--- a/ecommerce/payments/Gemfile.lock
+++ b/ecommerce/payments/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     minitest (5.15.0)
@@ -83,7 +83,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unparser (0.6.0)
       diff-lcs (~> 1.3)

--- a/ecommerce/pricing/Gemfile.lock
+++ b/ecommerce/pricing/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)

--- a/ecommerce/pricing/Gemfile.lock
+++ b/ecommerce/pricing/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       mutant (= 0.11.17)
     parser (3.1.2.1)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool

--- a/ecommerce/processes/Gemfile.lock
+++ b/ecommerce/processes/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       mutant (= 0.10.34)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool

--- a/ecommerce/processes/Gemfile.lock
+++ b/ecommerce/processes/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     minitest (5.15.0)
@@ -83,7 +83,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unparser (0.6.0)
       diff-lcs (~> 1.3)

--- a/ecommerce/product_catalog/Gemfile.lock
+++ b/ecommerce/product_catalog/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       mutant (= 0.10.34)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool

--- a/ecommerce/product_catalog/Gemfile.lock
+++ b/ecommerce/product_catalog/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     minitest (5.15.0)
@@ -83,7 +83,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unparser (0.6.0)
       diff-lcs (~> 1.3)

--- a/ecommerce/shipping/Gemfile.lock
+++ b/ecommerce/shipping/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       mutant (= 0.10.34)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool

--- a/ecommerce/shipping/Gemfile.lock
+++ b/ecommerce/shipping/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     minitest (5.15.0)
@@ -83,7 +83,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unparser (0.6.0)
       diff-lcs (~> 1.3)

--- a/ecommerce/taxes/Gemfile.lock
+++ b/ecommerce/taxes/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       mutant (= 0.10.34)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool

--- a/ecommerce/taxes/Gemfile.lock
+++ b/ecommerce/taxes/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     minitest (5.15.0)
@@ -83,7 +83,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unparser (0.6.0)
       diff-lcs (~> 1.3)

--- a/infra/Gemfile.lock
+++ b/infra/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     minitest (5.15.0)
@@ -85,7 +85,7 @@ GEM
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
     sorbet-runtime (0.5.10253)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unparser (0.6.5)
       diff-lcs (~> 1.3)

--- a/infra/Gemfile.lock
+++ b/infra/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       mutant (= 0.11.14)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump activesupport from 7.0.4 to 7.0.4.1 in /ecommerce/pricing (#250) @app/dependabot
* Bump activesupport from 7.0.3.1 to 7.0.4.1 in /ecommerce/inventory (#248) @app/dependabot
* Bump activesupport from 7.0.3 to 7.0.4.1 in /ecommerce/authentication (#247) @app/dependabot
* Bump activesupport from 7.0.3 to 7.0.4.1 in /ecommerce/invoicing (#246) @app/dependabot
* Bump activesupport from 7.0.3 to 7.0.4.1 in /ecommerce/payments (#245) @app/dependabot
* Bump activesupport from 7.0.3 to 7.0.4.1 in /ecommerce/crm (#244) @app/dependabot
* Bump activesupport from 7.0.3 to 7.0.4.1 in /ecommerce/processes (#243) @app/dependabot
* Bump activesupport from 7.0.3 to 7.0.4.1 in /ecommerce/taxes (#242) @app/dependabot
* Bump activesupport from 7.0.3 to 7.0.4.1 in /ecommerce/shipping (#241) @app/dependabot
* Bump activesupport from 7.0.3 to 7.0.4.1 in /infra (#240) @app/dependabot
* Bump activesupport from 7.0.3 to 7.0.4.1 in /ecommerce/product_catalog (#239) @app/dependabot
* Bump activesupport from 7.0.3 to 7.0.4.1 in /ecommerce/ordering (#238) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /ecommerce/inventory (#237) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /ecommerce/shipping (#236) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /ecommerce/payments (#235) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /ecommerce/crm (#234) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /ecommerce/invoicing (#233) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /ecommerce/authentication (#231) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /ecommerce/processes (#232) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /ecommerce/pricing (#230) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /ecommerce/product_catalog (#228) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /ecommerce/ordering (#229) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /infra (#227) @app/dependabot
* Bump rack from 3.0.2 to 3.0.4.1 in /ecommerce/taxes (#226) @app/dependabot
