### PR TITLE
Move Omnibus directive implementation to PublicOffer logic

### DIFF
--- a/rails_application/Gemfile
+++ b/rails_application/Gemfile
@@ -33,7 +33,6 @@ end
 
 group :test do
   eval_gemfile "../infra/Gemfile.test"
-  gem "timecop"
 end
 
 gem "infra", path: "../infra"

--- a/rails_application/Gemfile.lock
+++ b/rails_application/Gemfile.lock
@@ -308,7 +308,6 @@ GEM
     tailwindcss-rails (2.0.14-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.2.1)
-    timecop (0.9.6)
     timeout (0.3.0)
     turbo-rails (1.3.0)
       actionpack (>= 6.0.0)
@@ -357,7 +356,6 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   tailwindcss-rails
-  timecop
   turbo-rails
   tzinfo-data
 

--- a/rails_application/app/read_models/client_orders/configuration.rb
+++ b/rails_application/app/read_models/client_orders/configuration.rb
@@ -126,7 +126,6 @@ module ClientOrders
 
       event_store.subscribe(ChangeProductName, to: [ProductCatalog::ProductNamed])
       event_store.subscribe(ChangeProductPrice, to: [Pricing::PriceSet])
-      event_store.subscribe(RegisterLowestPrice, to: [Pricing::PriceSet])
       event_store.subscribe(RegisterProduct, to: [ProductCatalog::ProductRegistered])
       event_store.subscribe(UpdateDiscount, to: [Pricing::PercentageDiscountSet, Pricing::PercentageDiscountChanged])
       event_store.subscribe(ResetDiscount, to: [Pricing::PercentageDiscountReset])

--- a/rails_application/app/read_models/client_orders/product.rb
+++ b/rails_application/app/read_models/client_orders/product.rb
@@ -2,8 +2,6 @@ module ClientOrders
   class Product < ApplicationRecord
     self.table_name = "client_order_products"
 
-    def lowest_recent_price_lower_from_current?
-      lowest_recent_price < price
-    end
+    self.ignored_columns = ["lowest_recent_price"]
   end
 end

--- a/rails_application/app/read_models/client_orders/register_lowest_price.rb
+++ b/rails_application/app/read_models/client_orders/register_lowest_price.rb
@@ -57,6 +57,8 @@ module ClientOrders
         event.event_id,
         stream_name: stream_name(product_id)
       )
+    rescue RubyEventStore::EventDuplicatedInStream => error
+      Rails.logger.info("Duplicated event registered for PricesHistoryReport: #{error}")
     end
 
     def stream_name(product_id)

--- a/rails_application/app/read_models/public_offer/configuration.rb
+++ b/rails_application/app/read_models/public_offer/configuration.rb
@@ -1,8 +1,4 @@
 module PublicOffer
-  class Product < ApplicationRecord
-    self.table_name = "public_offer_products"
-  end
-
   class ProductsList < Arbre::Component
 
     def self.build(view_context)
@@ -19,7 +15,6 @@ module PublicOffer
     end
 
     private
-
 
     def products_table(products)
       if products.count > 0

--- a/rails_application/app/read_models/public_offer/configuration.rb
+++ b/rails_application/app/read_models/public_offer/configuration.rb
@@ -37,7 +37,16 @@ module PublicOffer
                   product.name
                 end
                 td class: "py-2 text-right" do
-                  number_to_currency(product.price)
+                  if product.lowest_recent_price_lower_from_current?
+                    span title: "Lowest recent price: #{number_to_currency(product.lowest_recent_price)}",
+                      id: "lowest-price-info-#{product.id}" do
+                      "ℹ️"
+                    end
+                  end
+
+                  span do
+                    number_to_currency(product.price)
+                  end
                 end
               end
             end

--- a/rails_application/app/read_models/public_offer/configuration.rb
+++ b/rails_application/app/read_models/public_offer/configuration.rb
@@ -54,12 +54,14 @@ module PublicOffer
   class Configuration
     def initialize(event_store)
       @read_model = SingleTableReadModel.new(event_store, Product, :product_id)
+      @event_store = event_store
     end
 
     def call
       @read_model.subscribe_create(ProductCatalog::ProductRegistered)
       @read_model.copy(ProductCatalog::ProductNamed,       :name)
       @read_model.copy(Pricing::PriceSet,                  :price)
+      @event_store.subscribe(RegisterLowestPrice, to: [Pricing::PriceSet])
     end
   end
 end

--- a/rails_application/app/read_models/public_offer/product.rb
+++ b/rails_application/app/read_models/public_offer/product.rb
@@ -1,0 +1,9 @@
+module PublicOffer
+  class Product < ApplicationRecord
+    self.table_name = "public_offer_products"
+
+    def lowest_recent_price_lower_from_current?
+      lowest_recent_price < price
+    end
+  end
+end

--- a/rails_application/app/read_models/public_offer/product.rb
+++ b/rails_application/app/read_models/public_offer/product.rb
@@ -3,7 +3,7 @@ module PublicOffer
     self.table_name = "public_offer_products"
 
     def lowest_recent_price_lower_from_current?
-      lowest_recent_price < price
+      lowest_recent_price && lowest_recent_price < price
     end
   end
 end

--- a/rails_application/app/read_models/public_offer/register_lowest_price.rb
+++ b/rails_application/app/read_models/public_offer/register_lowest_price.rb
@@ -1,4 +1,4 @@
-module ClientOrders
+module PublicOffer
   class RegisterLowestPrice < Infra::EventHandler
     RECENT_PERIOD = 30.days
 
@@ -9,7 +9,7 @@ module ClientOrders
 
       lowest_recent_price = lowest_recent_price_for(product_id)
 
-      product = Product.find_by_uid(product_id)
+      product = Product.find(product_id)
       product.update!(lowest_recent_price: lowest_recent_price)
     end
 

--- a/rails_application/app/views/client/orders/edit.html.erb
+++ b/rails_application/app/views/client/orders/edit.html.erb
@@ -15,17 +15,7 @@
       <% order_line = @order_lines&.find{|order_line| order_line.product_id == product.uid} %>
       <td class="py-2"><%= product.name %></td>
       <td class="py-2" id="<%= "client_orders_#{product.uid}_product_quantity" %>"><%= order_line.try(&:product_quantity) || 0 %></td>
-      <td class="py-2">
-        <%= number_to_currency(product.price) %>
-        <% if product.lowest_recent_price_lower_from_current? %>
-          <span
-            title="<%= "Lowest recent price: #{number_to_currency(product.lowest_recent_price)}"%>"
-            id="lowest-price-info-<%= product.uid %>"
-          >
-            ℹ️
-          </span>
-        <% end %>
-      </td>
+      <td class="py-2"><%= number_to_currency(product.price) %></td>
       <td class="py-2"  id="<%= "client_orders_#{product.uid}_value" %>"><%= number_to_currency(order_line.try(&:value)) %></td>
       <td class="py-2 text-right">
         <%= button_to "Add", add_item_client_order_path(id: @order_id, product_id: product.uid), class: "hover:underline text-blue-500" %>

--- a/rails_application/db/migrate/20230128110104_move_lowest_recent_price_to_public_offer.rb
+++ b/rails_application/db/migrate/20230128110104_move_lowest_recent_price_to_public_offer.rb
@@ -1,0 +1,16 @@
+class MoveLowestRecentPriceToPublicOffer < ActiveRecord::Migration[7.0]
+  def up
+    add_column :public_offer_products, :lowest_recent_price, :decimal, precision: 8, scale: 2
+
+    execute <<~SQL
+      UPDATE public_offer_products
+      SET lowest_recent_price = client_order_products.lowest_recent_price
+      FROM client_order_products
+      WHERE client_order_products.uid = public_offer_products.id
+    SQL
+  end
+
+  def down
+    remove_column :public_offer_products, :lowest_recent_price
+  end
+end

--- a/rails_application/db/schema.rb
+++ b/rails_application/db/schema.rb
@@ -181,6 +181,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_30_172623) do
     t.decimal "price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal "lowest_recent_price", precision: 8, scale: 2
   end
 
   create_table "shipments", force: :cascade do |t|

--- a/rails_application/test/client_orders/product_price_changed_test.rb
+++ b/rails_application/test/client_orders/product_price_changed_test.rb
@@ -45,9 +45,9 @@ module ClientOrders
     end
 
     def test_ignores_prices_older_than_30_days
-      product_id = prepare_product
+      freeze_time do
+        product_id = prepare_product
 
-      Timecop.freeze(Time.now) do
         set_past_price(product_id, 20, 31.days.ago.beginning_of_day.to_s)
         set_past_price(product_id, 25, (30.days.ago.beginning_of_day - 1.second).to_s)
         set_past_price(product_id, 30, 30.days.ago.beginning_of_day.to_s)

--- a/rails_application/test/client_orders/product_price_changed_test.rb
+++ b/rails_application/test/client_orders/product_price_changed_test.rb
@@ -80,6 +80,21 @@ module ClientOrders
       assert_equal 30, Product.find_by_uid(product1_id).lowest_recent_price
     end
 
+    def test_takes_last_event_when_no_events_in_last_30_days
+      product_id = SecureRandom.uuid
+      run_command(
+        ProductCatalog::RegisterProduct.new(
+          product_id: product_id,
+        )
+      )
+
+      set_past_price(product_id, 15, 45.days.ago.to_s)
+      set_past_price(product_id, 45, 32.days.ago.to_s)
+      set_future_price(product_id, 11, (Time.now + 2.days).to_s)
+
+      assert_equal 45, Product.find_by_uid(product_id).lowest_recent_price
+    end
+
     private
 
     def prepare_product

--- a/rails_application/test/client_orders/product_price_changed_test.rb
+++ b/rails_application/test/client_orders/product_price_changed_test.rb
@@ -14,87 +14,6 @@ module ClientOrders
       assert_equal 50, Product.find_by_uid(unchanged_product_id).price
     end
 
-    def test_registers_lowest_recent_price
-      product_id = prepare_product
-
-      set_price(product_id, 40)
-
-      assert_equal 40, Product.find_by_uid(product_id).lowest_recent_price
-    end
-
-    def test_keeps_lowest_recent_price
-      product_id = prepare_product
-
-      set_price(product_id, 100)
-      set_price(product_id, 20)
-      set_price(product_id, 50)
-      set_price(product_id, 70)
-
-      assert_equal 20, Product.find_by_uid(product_id).lowest_recent_price
-    end
-
-    def test_takes_into_account_price_set_before_30_days
-      product_id = prepare_product
-
-      set_price(product_id, 100)
-      set_past_price(product_id, 15, 31.days.ago.beginning_of_day.to_s)
-      set_price(product_id, 50)
-      set_price(product_id, 70)
-
-      assert_equal 15, Product.find_by_uid(product_id).lowest_recent_price
-    end
-
-    def test_ignores_prices_older_than_30_days
-      freeze_time do
-        product_id = prepare_product
-
-        set_past_price(product_id, 20, 31.days.ago.beginning_of_day.to_s)
-        set_past_price(product_id, 25, (30.days.ago.beginning_of_day - 1.second).to_s)
-        set_past_price(product_id, 30, 30.days.ago.beginning_of_day.to_s)
-        set_past_price(product_id, 32, (30.days.ago.beginning_of_day + 1.second).to_s)
-        set_past_price(product_id, 35, 30.days.ago.to_s)
-        set_past_price(product_id, 40, 29.days.ago.beginning_of_day.to_s)
-
-        assert_equal 30, Product.find_by_uid(product_id).lowest_recent_price
-      end
-    end
-
-    def test_ignores_future_prices
-      product_id = prepare_product
-
-      set_past_price(product_id, 45, 2.days.ago.to_s)
-      set_price(product_id, 35)
-      set_future_price(product_id, 11, (Time.now + 2.days).to_s)
-
-      assert_equal 35, Product.find_by_uid(product_id).lowest_recent_price
-    end
-
-    def test_ignores_other_products
-      product1_id = prepare_product
-      product2_id = prepare_product
-
-      set_price(product1_id, 35)
-      set_price(product2_id, 25)
-      set_price(product1_id, 30)
-
-      assert_equal 30, Product.find_by_uid(product1_id).lowest_recent_price
-    end
-
-    def test_takes_last_event_when_no_events_in_last_30_days
-      product_id = SecureRandom.uuid
-      run_command(
-        ProductCatalog::RegisterProduct.new(
-          product_id: product_id,
-        )
-      )
-
-      set_past_price(product_id, 15, 45.days.ago.to_s)
-      set_past_price(product_id, 45, 32.days.ago.to_s)
-      set_future_price(product_id, 11, (Time.now + 2.days).to_s)
-
-      assert_equal 45, Product.find_by_uid(product_id).lowest_recent_price
-    end
-
     private
 
     def prepare_product
@@ -118,10 +37,5 @@ module ClientOrders
     def set_price(product_id, amount)
       run_command(Pricing::SetPrice.new(product_id: product_id, price: amount))
     end
-
-    def set_future_price(product_id, amount, valid_since)
-      run_command(Pricing::SetFuturePrice.new(product_id: product_id, price: amount, valid_since: valid_since))
-    end
-    alias set_past_price set_future_price
   end
 end

--- a/rails_application/test/integration/client_orders_test.rb
+++ b/rails_application/test/integration/client_orders_test.rb
@@ -73,26 +73,6 @@ class ClientOrdersTests < InMemoryRESIntegrationTestCase
     assert_select("td", order_price)
   end
 
-  def test_showing_orders_with_information_about_the_lowest_price
-    client_id = register_customer('Arkency')
-    product1_id = register_product("Async Remote", 45, 10)
-    product2_id = register_product("Rails meets React.js", 50, 10)
-    update_price(product1_id, 30)
-    update_price(product2_id, 25)
-    update_price(product2_id, 70)
-
-    Sidekiq::Job.drain_all
-
-    get "/clients"
-    login(client_id)
-    get "/client_orders/new"
-    assert css_select("#lowest-price-info-#{product1_id}").empty?
-    assert css_select("#lowest-price-info-#{product2_id}").present?
-
-    info_icon = css_select("#lowest-price-info-#{product2_id}").first
-    assert_equal info_icon.attributes.fetch("title").value, "Lowest recent price: $25.00"
-  end
-
   def test_paid_orders_summary
     customer_id = register_customer("Customer Shop")
     product_1_id = register_product("Fearless Refactoring", 4, 10)

--- a/rails_application/test/integration/public_offer_test.rb
+++ b/rails_application/test/integration/public_offer_test.rb
@@ -19,4 +19,34 @@ class PublicOfferTest < InMemoryRESIntegrationTestCase
     assert_select("td", "$39.00")
   end
 
+  def test_showing_orders_with_information_about_the_lowest_price
+    client_id = register_customer('Arkency')
+    product1_id = register_product("Async Remote", 45, 10)
+    product2_id = register_product("Rails meets React.js", 50, 10)
+    update_price(product1_id, 30)
+    update_price(product2_id, 25)
+    update_price(product2_id, 70)
+
+    Sidekiq::Job.drain_all
+
+    get "/clients"
+    login(client_id)
+    get "/client/products"
+    assert css_select("#lowest-price-info-#{product1_id}").empty?
+    assert css_select("#lowest-price-info-#{product2_id}").present?
+
+    info_icon = css_select("#lowest-price-info-#{product2_id}").first
+    assert_equal info_icon.attributes.fetch("title").value, "Lowest recent price: $25.00"
+  end
+
+  private
+
+  def update_price(product_id, new_price)
+    patch "/products/#{product_id}",
+      params: {
+        "authenticity_token" => "[FILTERED]",
+        "product_id" => product_id,
+        price: new_price,
+      }
+  end
 end

--- a/rails_application/test/public_offer/product_price_changed_test.rb
+++ b/rails_application/test/public_offer/product_price_changed_test.rb
@@ -1,0 +1,127 @@
+require "test_helper"
+
+module PublicOffer
+  class ProductPriceChangedTest < InMemoryTestCase
+    cover "PublicOffer*"
+
+    def test_reflects_change
+      product_id = prepare_product
+      unchanged_product_id = prepare_product
+
+      set_price(product_id, 100)
+
+      assert_equal 100, Product.find(product_id).price
+      assert_equal 50, Product.find(unchanged_product_id).price
+    end
+
+    def test_registers_lowest_recent_price
+      product_id = prepare_product
+
+      set_price(product_id, 40)
+
+      assert_equal 40, Product.find(product_id).lowest_recent_price
+    end
+
+    def test_keeps_lowest_recent_price
+      product_id = prepare_product
+
+      set_price(product_id, 100)
+      set_price(product_id, 20)
+      set_price(product_id, 50)
+      set_price(product_id, 70)
+
+      assert_equal 20, Product.find(product_id).lowest_recent_price
+    end
+
+    def test_takes_into_account_price_set_before_30_days
+      product_id = prepare_product
+
+      set_price(product_id, 100)
+      set_past_price(product_id, 15, 31.days.ago.beginning_of_day.to_s)
+      set_price(product_id, 50)
+      set_price(product_id, 70)
+
+      assert_equal 15, Product.find(product_id).lowest_recent_price
+    end
+
+    def test_ignores_prices_older_than_30_days
+      freeze_time do
+        product_id = prepare_product
+
+        set_past_price(product_id, 20, 31.days.ago.beginning_of_day.to_s)
+        set_past_price(product_id, 25, (30.days.ago.beginning_of_day - 1.second).to_s)
+        set_past_price(product_id, 30, 30.days.ago.beginning_of_day.to_s)
+        set_past_price(product_id, 32, (30.days.ago.beginning_of_day + 1.second).to_s)
+        set_past_price(product_id, 35, 30.days.ago.to_s)
+        set_past_price(product_id, 40, 29.days.ago.beginning_of_day.to_s)
+
+        assert_equal 30, Product.find(product_id).lowest_recent_price
+      end
+    end
+
+    def test_ignores_future_prices
+      product_id = prepare_product
+
+      set_past_price(product_id, 45, 2.days.ago.to_s)
+      set_price(product_id, 35)
+      set_future_price(product_id, 11, (Time.now + 2.days).to_s)
+
+      assert_equal 35, Product.find(product_id).lowest_recent_price
+    end
+
+    def test_ignores_other_products
+      product1_id = prepare_product
+      product2_id = prepare_product
+
+      set_price(product1_id, 35)
+      set_price(product2_id, 25)
+      set_price(product1_id, 30)
+
+      assert_equal 30, Product.find(product1_id).lowest_recent_price
+    end
+
+    def test_takes_last_event_when_no_events_in_last_30_days
+      product_id = SecureRandom.uuid
+      run_command(
+        ProductCatalog::RegisterProduct.new(
+          product_id: product_id,
+        )
+      )
+
+      set_past_price(product_id, 15, 45.days.ago.to_s)
+      set_past_price(product_id, 45, 32.days.ago.to_s)
+      set_future_price(product_id, 11, (Time.now + 2.days).to_s)
+
+      assert_equal 45, Product.find(product_id).lowest_recent_price
+    end
+
+    private
+
+    def prepare_product
+      product_id = SecureRandom.uuid
+      run_command(
+        ProductCatalog::RegisterProduct.new(
+          product_id: product_id,
+          )
+      )
+      run_command(
+        ProductCatalog::NameProduct.new(
+          product_id: product_id,
+          name: "test"
+        )
+      )
+      run_command(Pricing::SetPrice.new(product_id: product_id, price: 50))
+
+      product_id
+    end
+
+    def set_price(product_id, amount)
+      run_command(Pricing::SetPrice.new(product_id: product_id, price: amount))
+    end
+
+    def set_future_price(product_id, amount, valid_since)
+      run_command(Pricing::SetFuturePrice.new(product_id: product_id, price: amount, valid_since: valid_since))
+    end
+    alias set_past_price set_future_price
+  end
+end


### PR DESCRIPTION
As explained in https://github.com/RailsEventStore/ecommerce/issues/268 we want to move the implementation from `ClientOrders` to `PublicOffer`. 

Apart from doing that, I'm also fixing a bug which was happening when no `PriceChanged` events were published in last 30 days and refactoring - removing `timecop` and using `freeze_time` instead.

Visual QA:

<img width="1372" alt="image" src="https://user-images.githubusercontent.com/12682792/215266040-4fd74108-30ec-4968-98cf-7de03d87ad82.png">
