### PR TITLE
[WIP] test adding item to order by client when item is out of stock

### DIFF
--- a/rails_application/test/test_helper.rb
+++ b/rails_application/test/test_helper.rb
@@ -86,6 +86,10 @@ class InMemoryRESIntegrationTestCase < ActionDispatch::IntegrationTest
     product_id
   end
 
+  def supply_product(product_id, quantity)
+    post "/products/#{product_id}/supplies", params: { quantity: quantity }
+  end
+
   def update_price(product_id, new_price)
     patch "/products/#{product_id}",
           params: {


### PR DESCRIPTION
[Work in progress]

I added two tests to cover this logic:
```
unless Availability.approximately_available?(params[:product_id], (read_model&.product_quantity || 0) + 1)
  redirect_to edit_client_order_path(params[:id]),
              alert: "Product not available in requested quantity!" and return
end
``` 
(https://github.com/marlena-b/ecommerce/blob/ec93d4d8c6bb6f104af16d8505fb20f3c87d2a99/rails_application/app/controllers/client/orders_controller.rb#L35)

`test_adding_product_which_is_not_available_in_requested_quantity` is fairly simple, it checks if correct error is displayed when someone tries to add more products to basket that there is available.

 `test_adding_product_which_is_not_available_anymore` checks the behavior when two users add the same product simultaneously and there is not enough stock for both of them. Interestingly it fails and then I manually checked in the UI and it is possible for both users to add the same product even if only 1 unit is available. Is this a desired behaviour and I should delete the test? Or is it a bug that should be fixed? 