### PR TITLE
Allow creating custom vat rates

### DIFF
--- a/ecommerce/configuration.rb
+++ b/ecommerce/configuration.rb
@@ -13,10 +13,9 @@ require_relative "processes/lib/processes"
 
 module Ecommerce
   class Configuration
-    def initialize(number_generator: nil, payment_gateway: nil, available_vat_rates: [])
+    def initialize(number_generator: nil, payment_gateway: nil)
       @number_generator = number_generator
       @payment_gateway = payment_gateway
-      @available_vat_rates = available_vat_rates
     end
 
     def call(event_store, command_bus)
@@ -37,7 +36,7 @@ module Ecommerce
         Payments::Configuration.new(@payment_gateway),
         Shipping::Configuration.new,
         Pricing::Configuration.new,
-        Taxes::Configuration.new(@available_vat_rates),
+        Taxes::Configuration.new,
         ProductCatalog::Configuration.new,
         Fulfillment::Configuration.new
       ].each { |c| c.call(event_store, command_bus) }

--- a/ecommerce/taxes/lib/taxes.rb
+++ b/ecommerce/taxes/lib/taxes.rb
@@ -7,18 +7,10 @@ require_relative 'taxes/vat_rate_catalog'
 
 module Taxes
   class Configuration
-    def self.available_vat_rates
-      @@available_vat_rates
-    end
-
-    def initialize(available_vat_rates = [])
-      @available_vat_rates = available_vat_rates
-    end
-
     def call(event_store, command_bus)
-      @@available_vat_rates = @available_vat_rates
       command_bus.register(SetVatRate, SetVatRateHandler.new(event_store))
       command_bus.register(DetermineVatRate, DetermineVatRateHandler.new(event_store))
+      command_bus.register(AddAvailableVatRate, AddAvailableVatRateHandler.new(event_store))
     end
   end
 end

--- a/ecommerce/taxes/lib/taxes/commands.rb
+++ b/ecommerce/taxes/lib/taxes/commands.rb
@@ -1,7 +1,7 @@
 module Taxes
   class SetVatRate < Infra::Command
     attribute :product_id, Infra::Types::UUID
-    attribute :vat_rate, Infra::Types::VatRate
+    attribute :vat_rate_code, Infra::Types::String
   end
 
   class DetermineVatRate < Infra::Command

--- a/ecommerce/taxes/lib/taxes/commands.rb
+++ b/ecommerce/taxes/lib/taxes/commands.rb
@@ -8,4 +8,9 @@ module Taxes
     attribute :product_id, Infra::Types::UUID
     attribute :order_id, Infra::Types::UUID
   end
+
+  class AddAvailableVatRate < Infra::Command
+    attribute :available_vat_rate_id, Infra::Types::UUID
+    attribute :vat_rate, Infra::Types::VatRate
+  end
 end

--- a/ecommerce/taxes/lib/taxes/events.rb
+++ b/ecommerce/taxes/lib/taxes/events.rb
@@ -9,4 +9,9 @@ module Taxes
     attribute :product_id, Infra::Types::UUID
     attribute :vat_rate, Infra::Types::VatRate
   end
+
+  class AvailableVatRateAdded < Infra::Event
+    attribute :available_vat_rate_id, Infra::Types::UUID
+    attribute :vat_rate, Infra::Types::VatRate
+  end
 end

--- a/ecommerce/taxes/lib/taxes/product.rb
+++ b/ecommerce/taxes/lib/taxes/product.rb
@@ -2,22 +2,15 @@ module Taxes
   class Product
     include AggregateRoot
 
-    VatRateNotApplicable = Class.new(StandardError)
-
     def initialize(id)
       @id = id
     end
 
-    def set_vat_rate(vat_rate, catalog)
-      raise VatRateNotApplicable unless vat_rate_applicable?(vat_rate.code, catalog)
+    def set_vat_rate(vat_rate)
       apply(VatRateSet.new(data: { product_id: @id, vat_rate: vat_rate }))
     end
 
     private
-
-    def vat_rate_applicable?(vat_rate_code, catalog)
-      catalog.vat_rate_available?(vat_rate_code)
-    end
 
     on(VatRateSet) { |_| }
   end

--- a/ecommerce/taxes/lib/taxes/product.rb
+++ b/ecommerce/taxes/lib/taxes/product.rb
@@ -8,15 +8,15 @@ module Taxes
       @id = id
     end
 
-    def set_vat_rate(vat_rate)
-      raise VatRateNotApplicable unless vat_rate_applicable?(vat_rate)
+    def set_vat_rate(vat_rate, catalog)
+      raise VatRateNotApplicable unless vat_rate_applicable?(vat_rate.code, catalog)
       apply(VatRateSet.new(data: { product_id: @id, vat_rate: vat_rate }))
     end
 
     private
 
-    def vat_rate_applicable?(vat_rate)
-      Configuration.available_vat_rates.include?(vat_rate)
+    def vat_rate_applicable?(vat_rate_code, catalog)
+      catalog.vat_rate_available?(vat_rate_code)
     end
 
     on(VatRateSet) { |_| }

--- a/ecommerce/taxes/lib/taxes/services.rb
+++ b/ecommerce/taxes/lib/taxes/services.rb
@@ -1,12 +1,14 @@
 module Taxes
+  VatRateAlreadyExists = Class.new(StandardError)
   class SetVatRateHandler
     def initialize(event_store)
       @repository = Infra::AggregateRootRepository.new(event_store)
+      @catalog = VatRateCatalog.new(event_store)
     end
 
     def call(cmd)
       @repository.with_aggregate(Product, cmd.product_id) do |product|
-        product.set_vat_rate(cmd.vat_rate)
+        product.set_vat_rate(cmd.vat_rate, @catalog)
       end
     end
   end
@@ -32,6 +34,36 @@ module Taxes
 
     def stream_name(order_id)
       "Taxes::Order$#{order_id}"
+    end
+  end
+
+  class AddAvailableVatRateHandler
+    def initialize(event_store)
+      @catalog = VatRateCatalog.new(event_store)
+      @event_store = event_store
+    end
+
+    def call(cmd)
+      raise VatRateAlreadyExists if catalog.vat_rate_available?(cmd.vat_rate.code)
+
+      event_store.publish(available_vat_rate_added_event(cmd), stream_name: stream_name(cmd))
+    end
+
+    private
+
+    attr_reader :event_store, :catalog
+
+    def available_vat_rate_added_event(cmd)
+      AvailableVatRateAdded.new(
+        data: {
+          available_vat_rate_id: cmd.available_vat_rate_id,
+          vat_rate: cmd.vat_rate
+        }
+      )
+    end
+
+    def stream_name(cmd)
+      "Taxes::AvailableVatRate$#{cmd.vat_rate.code}"
     end
   end
 end

--- a/ecommerce/taxes/lib/taxes/vat_rate_catalog.rb
+++ b/ecommerce/taxes/lib/taxes/vat_rate_catalog.rb
@@ -14,5 +14,13 @@ module Taxes
         &.data
         &.fetch(:vat_rate)
     end
+
+    def vat_rate_available?(vat_rate_code)
+      @event_store
+        .read
+        .stream("Taxes::AvailableVatRate$#{vat_rate_code}")
+        .to_a
+        .any?
+    end
   end
 end

--- a/ecommerce/taxes/lib/taxes/vat_rate_catalog.rb
+++ b/ecommerce/taxes/lib/taxes/vat_rate_catalog.rb
@@ -15,12 +15,14 @@ module Taxes
         &.fetch(:vat_rate)
     end
 
-    def vat_rate_available?(vat_rate_code)
+    def vat_rate_by_code(vat_rate_code)
       @event_store
         .read
         .stream("Taxes::AvailableVatRate$#{vat_rate_code}")
-        .to_a
-        .any?
+        .last
+        &.data
+        &.fetch(:vat_rate)
+        &.then { |vat_rate| Infra::Types::VatRate.new(vat_rate) }
     end
   end
 end

--- a/ecommerce/taxes/test/taxes_test.rb
+++ b/ecommerce/taxes/test/taxes_test.rb
@@ -3,32 +3,59 @@ require_relative "test_helper"
 module Taxes
   class TaxesTest < Test
     def test_setting_available_vat_rate
+      vat_rate = Infra::Types::VatRate.new(code: "50", rate: 50)
+      add_available_vat_rate(vat_rate)
+
       product_id = SecureRandom.uuid
-      vat_rate_set = VatRateSet.new(data: { product_id: product_id, vat_rate: available_vat_rate })
+      vat_rate_set = VatRateSet.new(data: { product_id: product_id, vat_rate: vat_rate })
       assert_events("Taxes::Product$#{product_id}", vat_rate_set) do
-        set_vat_rate(product_id, available_vat_rate)
+        set_vat_rate(product_id, vat_rate)
       end
     end
 
     def test_setting_unavailable_vat_rate_should_raise_error
       product_id = SecureRandom.uuid
+      unavailable_vat_rate = Infra::Types::VatRate.new(code: "20", rate: 20)
+
       assert_raises(Product::VatRateNotApplicable) do
         set_vat_rate(product_id, unavailable_vat_rate)
       end
     end
 
     def test_determining_vat_rate
+      vat_rate = Infra::Types::VatRate.new(code: "50", rate: 50)
+      add_available_vat_rate(vat_rate)
+
       order_id = SecureRandom.uuid
       product_id = SecureRandom.uuid
       another_product_id = SecureRandom.uuid
 
-      set_vat_rate(product_id, available_vat_rate)
-      vat_rate_determined = VatRateDetermined.new(data: { order_id: order_id, product_id: product_id, vat_rate: available_vat_rate })
+      set_vat_rate(product_id, vat_rate)
+      vat_rate_determined = VatRateDetermined.new(data: { order_id: order_id, product_id: product_id, vat_rate: vat_rate })
       assert_events("Taxes::Order$#{order_id}", vat_rate_determined) do
-        determine_vat_rate(order_id, product_id, available_vat_rate)
+        determine_vat_rate(order_id, product_id, vat_rate)
       end
       assert_events("Taxes::Order$#{order_id}") do
-        determine_vat_rate(order_id, another_product_id, available_vat_rate)
+        determine_vat_rate(order_id, another_product_id, vat_rate)
+      end
+    end
+
+    def test_adding_available_vat_rate
+      available_vat_rate_id = SecureRandom.uuid
+      vat_rate = Infra::Types::VatRate.new(code: "50", rate: 50)
+      available_vat_rate_added = AvailableVatRateAdded.new(data: { available_vat_rate_id: available_vat_rate_id, vat_rate: vat_rate })
+
+      assert_events("Taxes::AvailableVatRate$#{vat_rate.code}", available_vat_rate_added) do
+        add_available_vat_rate(vat_rate, available_vat_rate_id)
+      end
+    end
+
+    def test_should_not_allow_for_double_registration
+      vat_rate = Infra::Types::VatRate.new(code: "50", rate: 50)
+      add_available_vat_rate(vat_rate)
+
+      assert_raises(VatRateAlreadyExists) do
+        add_available_vat_rate(vat_rate)
       end
     end
 
@@ -42,12 +69,8 @@ module Taxes
       run_command(DetermineVatRate.new(order_id: order_id, product_id: product_id, vat_rate: vat_rate))
     end
 
-    def available_vat_rate
-      Configuration.available_vat_rates.first
-    end
-
-    def unavailable_vat_rate
-      Infra::Types::VatRate.new(code: "50", rate: 50)
+    def add_available_vat_rate(vat_rate, available_vat_rate_id = SecureRandom.uuid)
+      run_command(AddAvailableVatRate.new(available_vat_rate_id: available_vat_rate_id, vat_rate: vat_rate))
     end
   end
 end

--- a/ecommerce/taxes/test/taxes_test.rb
+++ b/ecommerce/taxes/test/taxes_test.rb
@@ -9,7 +9,7 @@ module Taxes
       product_id = SecureRandom.uuid
       vat_rate_set = VatRateSet.new(data: { product_id: product_id, vat_rate: vat_rate })
       assert_events("Taxes::Product$#{product_id}", vat_rate_set) do
-        set_vat_rate(product_id, vat_rate)
+        set_vat_rate(product_id, vat_rate.code)
       end
     end
 
@@ -17,8 +17,8 @@ module Taxes
       product_id = SecureRandom.uuid
       unavailable_vat_rate = Infra::Types::VatRate.new(code: "20", rate: 20)
 
-      assert_raises(Product::VatRateNotApplicable) do
-        set_vat_rate(product_id, unavailable_vat_rate)
+      assert_raises(Taxes::VatRateNotApplicable) do
+        set_vat_rate(product_id, unavailable_vat_rate.code)
       end
     end
 
@@ -30,7 +30,7 @@ module Taxes
       product_id = SecureRandom.uuid
       another_product_id = SecureRandom.uuid
 
-      set_vat_rate(product_id, vat_rate)
+      set_vat_rate(product_id, vat_rate.code)
       vat_rate_determined = VatRateDetermined.new(data: { order_id: order_id, product_id: product_id, vat_rate: vat_rate })
       assert_events("Taxes::Order$#{order_id}", vat_rate_determined) do
         determine_vat_rate(order_id, product_id, vat_rate)
@@ -61,8 +61,8 @@ module Taxes
 
     private
 
-    def set_vat_rate(product_id, vat_rate)
-      run_command(SetVatRate.new(product_id: product_id, vat_rate: vat_rate))
+    def set_vat_rate(product_id, vat_rate_code)
+      run_command(SetVatRate.new(product_id: product_id, vat_rate_code: vat_rate_code))
     end
 
     def determine_vat_rate(order_id, product_id, vat_rate)

--- a/ecommerce/taxes/test/test_helper.rb
+++ b/ecommerce/taxes/test/test_helper.rb
@@ -9,13 +9,7 @@ module Taxes
 
     def before_setup
       super
-      Configuration.new([dummy_vat_rate]).call(event_store, command_bus)
-    end
-
-    private
-
-    def dummy_vat_rate
-      Infra::Types::VatRate.new(code: "20", rate: 20)
+      Configuration.new.call(event_store, command_bus)
     end
   end
 end

--- a/ecommerce/taxes/test/vat_rate_catalog_test.rb
+++ b/ecommerce/taxes/test/vat_rate_catalog_test.rb
@@ -2,28 +2,20 @@ require_relative "test_helper"
 
 module Taxes
   class VatRateCatalogTest < Test
-    class VatRateAvailableTest < VatRateCatalogTest
-      def test_returns_true_when_vat_rate_is_available
-        vat_rate = Infra::Types::VatRate.new(code: "50", rate: 50)
-        add_available_vat_rate(vat_rate)
-
-        assert catalog.vat_rate_available?(vat_rate.code)
+    class VatRateByCodeTest < VatRateCatalogTest
+      def setup
+        @vat_rate = Infra::Types::VatRate.new(code: "50", rate: 50)
+        add_available_vat_rate(@vat_rate)
       end
 
-      def test_returns_false_when_vat_rate_is_not_available
-        vat_rate = Infra::Types::VatRate.new(code: "50", rate: 50)
-
-        refute catalog.vat_rate_available?(vat_rate.code)
+      def test_returns_available_vat_rate
+        assert_equal @vat_rate, catalog.vat_rate_by_code("50")
       end
 
-      def test_returns_false_when_vat_rate_is_not_available_even_when_other_vat_rates_are_available
-        vat_rate = Infra::Types::VatRate.new(code: "50", rate: 50)
-        add_available_vat_rate(vat_rate)
-
-        refute catalog.vat_rate_available?("60")
+      def test_returns_nil_when_vat_rate_is_not_available
+        assert_nil catalog.vat_rate_by_code("60")
       end
     end
-
 
     private
 

--- a/ecommerce/taxes/test/vat_rate_catalog_test.rb
+++ b/ecommerce/taxes/test/vat_rate_catalog_test.rb
@@ -1,0 +1,38 @@
+require_relative "test_helper"
+
+module Taxes
+  class VatRateCatalogTest < Test
+    class VatRateAvailableTest < VatRateCatalogTest
+      def test_returns_true_when_vat_rate_is_available
+        vat_rate = Infra::Types::VatRate.new(code: "50", rate: 50)
+        add_available_vat_rate(vat_rate)
+
+        assert catalog.vat_rate_available?(vat_rate.code)
+      end
+
+      def test_returns_false_when_vat_rate_is_not_available
+        vat_rate = Infra::Types::VatRate.new(code: "50", rate: 50)
+
+        refute catalog.vat_rate_available?(vat_rate.code)
+      end
+
+      def test_returns_false_when_vat_rate_is_not_available_even_when_other_vat_rates_are_available
+        vat_rate = Infra::Types::VatRate.new(code: "50", rate: 50)
+        add_available_vat_rate(vat_rate)
+
+        refute catalog.vat_rate_available?("60")
+      end
+    end
+
+
+    private
+
+    def catalog
+      VatRateCatalog.new(@event_store)
+    end
+
+    def add_available_vat_rate(vat_rate, available_vat_rate_id = SecureRandom.uuid)
+      run_command(AddAvailableVatRate.new(available_vat_rate_id: available_vat_rate_id, vat_rate: vat_rate))
+    end
+  end
+end

--- a/rails_application/app/controllers/available_vat_rates_controller.rb
+++ b/rails_application/app/controllers/available_vat_rates_controller.rb
@@ -1,14 +1,17 @@
 class AvailableVatRatesController < ApplicationController
   class AvailableVatRateForm
     include ActiveModel::Model
-    include ActiveModel::Attributes
     include ActiveModel::Validations
 
-    attribute :code, :string
-    attribute :rate, :decimal
+    attr_reader :code, :rate
+
+    def initialize(params)
+      @code = params[:code]
+      @rate = params[:rate]
+    end
 
     validates :code, presence: true
-    validates :rate, presence: true, numericality: { greater_than: 0 }
+    validates :rate, presence: true, numericality: { only_numeric: true, greater_than: 0 }
   end
 
   def new

--- a/rails_application/app/controllers/available_vat_rates_controller.rb
+++ b/rails_application/app/controllers/available_vat_rates_controller.rb
@@ -1,0 +1,53 @@
+class AvailableVatRatesController < ApplicationController
+  class AvailableVatRateForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations
+
+    attribute :code, :string
+    attribute :rate, :decimal
+
+    validates :code, presence: true
+    validates :rate, presence: true, numericality: { greater_than: 0 }
+  end
+
+  def new
+  end
+
+  def create
+    available_vat_rate_id = SecureRandom.uuid
+    available_vat_rate_form = AvailableVatRateForm.new(available_vat_rate_params)
+
+    unless available_vat_rate_form.valid?
+      return render "new", locals: { errors: available_vat_rate_form.errors }, status: :unprocessable_entity
+    end
+
+    add_available_vat_rate(available_vat_rate_form.code, available_vat_rate_form.rate, available_vat_rate_id)
+    rescue Taxes::VatRateAlreadyExists
+      flash.now[:notice] = "VAT rate already exists"
+      render "new", status: :unprocessable_entity
+    else
+    redirect_to available_vat_rates_path, notice: "VAT rate was successfully created"
+  end
+
+  def index
+    @available_vat_rates = VatRates::AvailableVatRate.all
+  end
+
+  private
+
+  def add_available_vat_rate(code, rate, available_vat_rate_id)
+    command_bus.(add_available_vat_rate_cmd(code, rate, available_vat_rate_id))
+  end
+
+  def add_available_vat_rate_cmd(code, rate, available_vat_rate_id)
+    Taxes::AddAvailableVatRate.new(
+      available_vat_rate_id: available_vat_rate_id,
+      vat_rate: Infra::Types::VatRate.new(code: code, rate: rate)
+    )
+  end
+
+  def available_vat_rate_params
+    params.permit(:code, :rate)
+  end
+end

--- a/rails_application/app/controllers/products_controller.rb
+++ b/rails_application/app/controllers/products_controller.rb
@@ -46,15 +46,15 @@ class ProductsController < ApplicationController
       if product_form.vat_rate.present?
         set_product_vat_rate(product_form.product_id, product_form.vat_rate)
       end
-    rescue ProductCatalog::AlreadyRegistered
-      flash[:notice] = "Product was already registered"
-      render "new"
-    rescue Taxes::Product::VatRateNotApplicable
-      flash[:notice] = "Selected VAT rate not applicable"
-      render "new"
-    else
-      redirect_to products_path, notice: "Product was successfully created"
     end
+
+    redirect_to products_path, notice: "Product was successfully created"
+  rescue ProductCatalog::AlreadyRegistered
+    flash[:notice] = "Product was already registered"
+    render "new"
+  rescue Taxes::VatRateNotApplicable
+    flash[:notice] = "Selected VAT rate is not applicable"
+    render "new"
   end
 
   def update
@@ -92,7 +92,6 @@ class ProductsController < ApplicationController
   end
 
   def set_product_vat_rate(product_id, vat_rate)
-    vat_rate = VatRates::AvailableVatRate.find_by!(code: vat_rate).to_value
     command_bus.(set_product_vat_rate_cmd(product_id, vat_rate))
   end
 
@@ -113,7 +112,7 @@ class ProductsController < ApplicationController
   end
 
   def set_product_vat_rate_cmd(product_id, vat_rate)
-    Taxes::SetVatRate.new(product_id: product_id, vat_rate: vat_rate)
+    Taxes::SetVatRate.new(product_id: product_id, vat_rate_code: vat_rate)
   end
 
   def set_product_future_price_cmd(product_id, price, valid_since)

--- a/rails_application/app/controllers/products_controller.rb
+++ b/rails_application/app/controllers/products_controller.rb
@@ -91,8 +91,8 @@ class ProductsController < ApplicationController
     command_bus.(set_product_future_price_cmd(product_id, price, valid_since))
   end
 
-  def set_product_vat_rate(product_id, vat_rate_code)
-    vat_rate = Taxes::Configuration.available_vat_rates.find{|rate| rate.code == vat_rate_code}
+  def set_product_vat_rate(product_id, vat_rate)
+    vat_rate = VatRates::AvailableVatRate.find_by!(code: vat_rate).to_value
     command_bus.(set_product_vat_rate_cmd(product_id, vat_rate))
   end
 

--- a/rails_application/app/read_models/vat_rates/add_available_vat_rate.rb
+++ b/rails_application/app/read_models/vat_rates/add_available_vat_rate.rb
@@ -1,0 +1,11 @@
+module VatRates
+  class AddAvailableVatRate
+    def call(event)
+      AvailableVatRate.create!(
+        uid: event.data.fetch(:available_vat_rate_id),
+        code: event.data.fetch(:vat_rate).fetch(:code),
+        rate: event.data.fetch(:vat_rate).fetch(:rate)
+      )
+    end
+  end
+end

--- a/rails_application/app/read_models/vat_rates/configuration.rb
+++ b/rails_application/app/read_models/vat_rates/configuration.rb
@@ -1,10 +1,6 @@
 module VatRates
   class AvailableVatRate < ApplicationRecord
     self.table_name = "available_vat_rates"
-
-    def to_value
-      Infra::Types::VatRate.new(code: code, rate: rate)
-    end
   end
 
   class Configuration

--- a/rails_application/app/read_models/vat_rates/configuration.rb
+++ b/rails_application/app/read_models/vat_rates/configuration.rb
@@ -1,0 +1,15 @@
+module VatRates
+  class AvailableVatRate < ApplicationRecord
+    self.table_name = "available_vat_rates"
+
+    def to_value
+      Infra::Types::VatRate.new(code: code, rate: rate)
+    end
+  end
+
+  class Configuration
+    def call(event_store)
+      event_store.subscribe(AddAvailableVatRate, to: [Taxes::AvailableVatRateAdded])
+    end
+  end
+end

--- a/rails_application/app/views/application/_top_navigation.html.erb
+++ b/rails_application/app/views/application/_top_navigation.html.erb
@@ -15,6 +15,7 @@
             <%= navigation_link "Coupons", coupons_path %>
             <%= navigation_link "Time Promotions", time_promotions_path %>
             <%= navigation_link "Customers", customers_path %>
+            <%= navigation_link "VAT Rates", available_vat_rates_path %>
             <%= navigation_link "Client View", clients_path %>
           </div>
         </div>

--- a/rails_application/app/views/available_vat_rates/index.html.erb
+++ b/rails_application/app/views/available_vat_rates/index.html.erb
@@ -1,0 +1,27 @@
+<% content_for(:header) do %>
+  VAT Rates
+<% end %>
+
+<% content_for(:actions) do %>
+  <%= primary_action_button do %>
+    <%= link_to 'New VAT Rate', new_available_vat_rate_path %>
+  <% end %>
+<% end %>
+
+<table class="w-full">
+  <thead>
+    <tr>
+      <th class="text-left py-2">Code</th>
+      <th class="text-right py-2">Rate</th>
+    </tr>
+  </thead>
+
+  <tbody>
+  <% @available_vat_rates.each do |available_vat_rate| %>
+    <tr class="border-t">
+      <td class="py-2"><%= available_vat_rate.code %></td>
+      <td class="py-2 text-right"><%= available_vat_rate.rate %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/rails_application/app/views/available_vat_rates/new.html.erb
+++ b/rails_application/app/views/available_vat_rates/new.html.erb
@@ -1,0 +1,37 @@
+<% content_for(:header) do %>
+  New VAT Rate
+<% end %>
+
+<% content_for(:actions) do %>
+  <%= secondary_action_button do %>
+    <%= link_to 'Back', available_vat_rates_path %>
+  <% end %>
+
+  <%= primary_form_action_button do %>
+    Create VAT Rate
+  <% end %>
+<% end %>
+
+
+<%= form_tag({ controller: "available_vat_rates", action: "create" }, method: "post", id: "form") do %>
+  <div>
+    <label for="code" class="block font-bold">
+      Code
+    </label>
+    <%= text_field_tag :code, "", required: true, class: "mt-1 focus:ring-blue-500 focus:border-blue-500 block shadow-sm sm:text-sm border-gray-300 rounded-md", data: { turbo_permanent: true } %>
+  </div>
+  <div class="mt-2">
+    <label for="rate" class="block font-bold">
+      Rate
+    </label>
+    <%= number_field_tag :rate, nil, min: 0, step: 1.0, required: true, class: "mt-1 focus:ring-blue-500 focus:border-blue-500 block shadow-sm sm:text-sm border-gray-300 rounded-md", data: { turbo_permanent: true } %>
+  </div>
+
+  <% if defined?(errors) %>
+    <% errors.each do |error| %>
+      <div class="mt-2 text-red-600">
+        <span><%= error.full_message %></span>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/rails_application/app/views/products/new.html.erb
+++ b/rails_application/app/views/products/new.html.erb
@@ -32,7 +32,7 @@
       <label for="vat_rate" class="block font-bold">
         VAT rate
       </label>
-      <%= select_tag :vat_rate, options_from_collection_for_select(Taxes::Configuration.available_vat_rates, :code, :code), class: "mt-1 focus:ring-blue-500 focus:border-blue-500 block shadow-sm sm:text-sm border-gray-300 rounded-md", data: { turbo_permanent: true } %>
+      <%= select_tag :vat_rate, options_from_collection_for_select(VatRates::AvailableVatRate.all, :code, :code), class: "mt-1 focus:ring-blue-500 focus:border-blue-500 block shadow-sm sm:text-sm border-gray-300 rounded-md", data: { turbo_permanent: true } %>
     </div>
 
     <% if defined?(errors) %>

--- a/rails_application/config/routes.rb
+++ b/rails_application/config/routes.rb
@@ -46,6 +46,9 @@ Rails.application.routes.draw do
       post :remove_item
     end
   end
+
+  resources :available_vat_rates, only: [:new, :create, :index]
+
   post :login, to: "client/clients#login"
   get :logout, to: "client/clients#logout"
   get "clients", to: "client/clients#index"

--- a/rails_application/db/migrate/20240812080357_create_available_vat_rates.rb
+++ b/rails_application/db/migrate/20240812080357_create_available_vat_rates.rb
@@ -1,0 +1,11 @@
+class CreateAvailableVatRates < ActiveRecord::Migration[7.0]
+  def change
+    create_table :available_vat_rates do |t|
+      t.uuid :uid, null: false
+      t.string :code, null: false
+      t.decimal :rate, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/rails_application/db/schema.rb
+++ b/rails_application/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_06_105318) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_12_080357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -24,6 +24,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_105318) do
   create_table "availability_products", force: :cascade do |t|
     t.uuid "uid"
     t.integer "available"
+  end
+
+  create_table "available_vat_rates", force: :cascade do |t|
+    t.uuid "uid", null: false
+    t.string "code", null: false
+    t.decimal "rate", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "client_order_lines", force: :cascade do |t|

--- a/rails_application/db/seeds.rb
+++ b/rails_application/db/seeds.rb
@@ -37,6 +37,18 @@ end
 end
 
 [
+  ["20", 20],
+  ["10", 10]
+].each do |vat_rate|
+  command_bus.call(
+    Taxes::AddAvailableVatRate.new(
+      available_vat_rate_id: SecureRandom.uuid,
+      vat_rate: Infra::Types::VatRate.new(code: vat_rate[0], rate: vat_rate[1])
+    )
+  )
+end
+
+[
   ["Fearless Refactoring: Rails controllers", 49],
   ["Rails meets React.js", 49],
   ["Developers Oriented Project Management", 39],
@@ -47,7 +59,7 @@ end
     ProductCatalog::RegisterProduct.new(product_id: product_id),
     ProductCatalog::NameProduct.new(product_id: product_id, name: name_price_tuple[0]),
     Pricing::SetPrice.new(product_id: product_id, price: name_price_tuple[1]),
-    Taxes::SetVatRate.new(product_id: product_id, vat_rate: Taxes::Configuration.available_vat_rates.first)
+    Taxes::SetVatRate.new(product_id: product_id, vat_rate: VatRates::AvailableVatRate.first.to_value)
   ].each do |command|
     command_bus.call(command)
   end

--- a/rails_application/db/seeds.rb
+++ b/rails_application/db/seeds.rb
@@ -59,7 +59,7 @@ end
     ProductCatalog::RegisterProduct.new(product_id: product_id),
     ProductCatalog::NameProduct.new(product_id: product_id, name: name_price_tuple[0]),
     Pricing::SetPrice.new(product_id: product_id, price: name_price_tuple[1]),
-    Taxes::SetVatRate.new(product_id: product_id, vat_rate: VatRates::AvailableVatRate.first.to_value)
+    Taxes::SetVatRate.new(product_id: product_id, vat_rate_code: "20")
   ].each do |command|
     command_bus.call(command)
   end

--- a/rails_application/lib/configuration.rb
+++ b/rails_application/lib/configuration.rb
@@ -16,14 +16,11 @@ class Configuration
     enable_shipments_read_model(event_store)
     enable_availability_read_model(event_store)
     enable_authentication_read_model(event_store)
+    enable_vat_rates_read_model(event_store)
 
     Ecommerce::Configuration.new(
       number_generator: Rails.configuration.number_generator,
-      payment_gateway: Rails.configuration.payment_gateway,
-      available_vat_rates: [
-        Infra::Types::VatRate.new(code: "10", rate: 10),
-        Infra::Types::VatRate.new(code: "20", rate: 20)
-    ]
+      payment_gateway: Rails.configuration.payment_gateway
     ).call(event_store, command_bus)
   end
 
@@ -79,5 +76,9 @@ class Configuration
 
   def enable_authentication_read_model(event_store)
     ClientAuthentication::Configuration.new.call(event_store)
+  end
+
+  def enable_vat_rates_read_model(event_store)
+    VatRates::Configuration.new.call(event_store)
   end
 end

--- a/rails_application/test/integration/available_vat_rates_test.rb
+++ b/rails_application/test/integration/available_vat_rates_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class AvailableVatRatesTest < InMemoryRESIntegrationTestCase
+  def test_happy_path
+    get "/available_vat_rates/new"
+    assert_select "h1", "New VAT Rate"
+
+    post "/available_vat_rates",
+         params: {
+           "authenticity_token" => "[FILTERED]",
+           "code" => "10.0",
+           "rate" => 10.0
+         }
+    follow_redirect!
+
+    assert_equal "VAT rate was successfully created", flash[:notice]
+    assert_select "h1", "VAT Rates"
+  end
+
+  def test_validation_errors
+    post "/available_vat_rates",
+         params: {
+           "authenticity_token" => "[FILTERED]",
+           "code" => "",
+           "rate" => ""
+         }
+    assert_response :unprocessable_entity
+
+    assert_select "h1", "New VAT Rate"
+    assert_select "span", "Code can't be blank"
+    assert_select "span", "Rate can't be blank"
+  end
+
+  def test_vat_rate_already_exists
+    post "/available_vat_rates",
+        params: {
+          "authenticity_token" => "[FILTERED]",
+          "code" => "10.0",
+          "rate" => 10.0
+        }
+
+    post "/available_vat_rates",
+        params: {
+          "authenticity_token" => "[FILTERED]",
+          "code" => "10.0",
+          "rate" => 10.0
+        }
+
+    assert_response :unprocessable_entity
+    assert_select "#notice", "VAT rate already exists"
+  end
+end

--- a/rails_application/test/integration/client_orders_test.rb
+++ b/rails_application/test/integration/client_orders_test.rb
@@ -9,6 +9,7 @@ class ClientOrdersTests < InMemoryRESIntegrationTestCase
     ClientOrders::Client.destroy_all
     ClientOrders::Order.destroy_all
     Orders::Order.destroy_all
+    add_available_vat_rate(10)
   end
 
   def test_happy_path

--- a/rails_application/test/integration/customers_test.rb
+++ b/rails_application/test/integration/customers_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class CustomersTest < InMemoryRESIntegrationTestCase
+  def setup
+    super
+    add_available_vat_rate(10)
+  end
+
   def test_list_customers
     get "/customers"
     assert_response :success

--- a/rails_application/test/integration/discount_test.rb
+++ b/rails_application/test/integration/discount_test.rb
@@ -4,6 +4,7 @@ class DiscountTest < InMemoryRESIntegrationTestCase
   def setup
     super
     Orders::Order.destroy_all
+    add_available_vat_rate(10)
   end
 
   def test_reset_discount
@@ -40,4 +41,3 @@ class DiscountTest < InMemoryRESIntegrationTestCase
     assert_select("td", "$123.30")
   end
 end
-

--- a/rails_application/test/integration/orders_test.rb
+++ b/rails_application/test/integration/orders_test.rb
@@ -5,6 +5,7 @@ class OrdersTest < InMemoryRESIntegrationTestCase
     super
     Rails.configuration.payment_gateway.call.reset
     Orders::Order.destroy_all
+    add_available_vat_rate(10)
   end
 
   def test_submitting_empty_order

--- a/rails_application/test/integration/products_test.rb
+++ b/rails_application/test/integration/products_test.rb
@@ -8,6 +8,7 @@ class ProductsTest < InMemoryRESIntegrationTestCase
   end
 
   def test_happy_path
+    add_available_vat_rate(10)
     register_customer("Arkency")
     product_id = SecureRandom.uuid
 

--- a/rails_application/test/integration/public_offer_test.rb
+++ b/rails_application/test/integration/public_offer_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class PublicOfferTest < InMemoryRESIntegrationTestCase
   def setup
     super
+    add_available_vat_rate(10)
   end
 
   def test_happy_path

--- a/rails_application/test/invoices/invoices_test.rb
+++ b/rails_application/test/invoices/invoices_test.rb
@@ -29,27 +29,28 @@ module Invoices
       product_id = SecureRandom.uuid
       initial_product_name = "Initial Name"
       updated_product_name = "Updated Name"
-      
+
+      add_available_vat_rate(20)
       product_id = register_product(initial_product_name, 100, 20)
       customer_id = register_customer("Test Customer")
-      
+
       order_id = SecureRandom.uuid
       add_product_to_basket(order_id, product_id)
       submit_order(customer_id, order_id)
-      
+
       update_product_name(product_id, updated_product_name)
-      
+
       assert_invoice_product_name(order_id, initial_product_name)
 
       new_order_id = SecureRandom.uuid
       add_product_to_basket(new_order_id, product_id)
       submit_order(customer_id, new_order_id)
-  
+
       assert_invoice_product_name(new_order_id, updated_product_name)
     end
-    
+
     private
-    
+
     def update_product_name(product_id, new_name)
       patch "/products/#{product_id}",
             params: {
@@ -58,7 +59,7 @@ module Invoices
               name: new_name,
             }
     end
-    
+
     def assert_invoice_product_name(order_id, expected_name)
       get "/invoices/#{order_id}"
       assert_response :success

--- a/rails_application/test/read_model_handler_test.rb
+++ b/rails_application/test/read_model_handler_test.rb
@@ -101,7 +101,7 @@ class ReadModelHandlerTest < InMemoryTestCase
   end
 
   def available_vat_rate
-    Taxes::Configuration.available_vat_rates.first
+    Infra::Types::VatRate.new(code: "10", rate: 10)
   end
 
   def event_store

--- a/rails_application/test/test_helper.rb
+++ b/rails_application/test/test_helper.rb
@@ -81,9 +81,14 @@ class InMemoryRESIntegrationTestCase < ActionDispatch::IntegrationTest
   end
 
   def register_product(name, price, vat_rate)
+    add_available_vat_rate(vat_rate)
     product_id = SecureRandom.uuid
     post "/products", params: { product_id: product_id, name: name, price: price, vat_rate: vat_rate }
     product_id
+  end
+
+  def add_available_vat_rate(rate, code = rate.to_s)
+    post "/available_vat_rates", params: { code: code, rate: rate }
   end
 
   def supply_product(product_id, quantity)

--- a/rails_application/test/test_helper.rb
+++ b/rails_application/test/test_helper.rb
@@ -81,7 +81,6 @@ class InMemoryRESIntegrationTestCase < ActionDispatch::IntegrationTest
   end
 
   def register_product(name, price, vat_rate)
-    add_available_vat_rate(vat_rate)
     product_id = SecureRandom.uuid
     post "/products", params: { product_id: product_id, name: name, price: price, vat_rate: vat_rate }
     product_id

--- a/rails_application/test/vat_rates/available_vat_rate_added_test.rb
+++ b/rails_application/test/vat_rates/available_vat_rate_added_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+module VatRates
+  class AvailableVatRateAddedTest < InMemoryTestCase
+    cover "VatRates*"
+
+    def test_adding_available_vat_rate
+      uid = SecureRandom.uuid
+      code = "50"
+      rate = 50
+
+      event_store.publish(available_vat_rate_added_event(uid, code, rate))
+      available_vat_rate = AvailableVatRate.find_by_uid(uid)
+
+      assert_equal(uid, available_vat_rate.uid)
+      assert_equal(code, available_vat_rate.code)
+      assert_equal(rate, available_vat_rate.rate)
+    end
+
+    private
+
+    def event_store
+      Rails.configuration.event_store
+    end
+
+    def available_vat_rate_added_event(uid, code, rate)
+      Taxes::AvailableVatRateAdded.new(
+        data: {
+          available_vat_rate_id: uid,
+          vat_rate:
+            {
+              code: code,
+              rate: rate
+            }
+          }
+        )
+    end
+  end
+end


### PR DESCRIPTION
Issue: https://github.com/RailsEventStore/ecommerce/issues/174

This PR lets users create custom VAT rates. Previously, VAT rates were hardcoded in the configuration files, but now users can add their own. It is not possible to add two VAT rates with the same code (it would be very confusing if we had duplicates).

In my changes VAT rate codes can be strings, like "20.0 % S" or "5.0 % R" ([source](https://www.tide.co/blog/business-tips/vat-codes/)). However, when adding a product, the system still checks if the VAT rate code is a number, which breaks the flow for vat rates with string names. I’ll fix that in a separate PR, along with some confusing naming, to keep this one focused.


https://github.com/user-attachments/assets/e9aee011-ae6b-4c3f-9fb2-81e48ff91558


