### PR TITLE
BE validation for supply product

### DIFF
--- a/rails_application/app/controllers/supplies_controller.rb
+++ b/rails_application/app/controllers/supplies_controller.rb
@@ -1,10 +1,31 @@
 class SuppliesController < ApplicationController
+  class SupplyForm
+    include ActiveModel::Model
+    include ActiveModel::Validations
+
+    attr_reader :product_id, :quantity
+
+    def initialize(params)
+      @product_id = params[:product_id]
+      @quantity = params[:quantity]
+    end
+
+    validates :product_id, presence: true
+    validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0, allow_blank: true, only_numeric: true }
+  end
+
   def new
     @product_id = params[:product_id]
   end
 
   def create
-    supply(params[:product_id], params[:quantity])
+    supply_form = SupplyForm.new(supply_params)
+
+    unless supply_form.valid?
+      return render "new", locals: { errors: supply_form.errors }, status: :unprocessable_entity
+    end
+
+    supply(supply_form.product_id, supply_form.quantity.to_i)
     redirect_to products_path, notice: "Stock level changed"
   end
 
@@ -14,5 +35,9 @@ class SuppliesController < ApplicationController
     command_bus.(
       Inventory::Supply.new(product_id: product_id, quantity: quantity)
     )
+  end
+
+  def supply_params
+    params.permit(:product_id, :quantity)
   end
 end

--- a/rails_application/app/controllers/supplies_controller.rb
+++ b/rails_application/app/controllers/supplies_controller.rb
@@ -11,7 +11,7 @@ class SuppliesController < ApplicationController
     end
 
     validates :product_id, presence: true
-    validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0, allow_blank: true, only_numeric: true }
+    validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0, allow_blank: true }
   end
 
   def new

--- a/rails_application/app/views/supplies/new.html.erb
+++ b/rails_application/app/views/supplies/new.html.erb
@@ -18,5 +18,15 @@
   <label for="quantity" class="block font-bold">
     Quantity
   </label>
-  <%= number_field_tag :quantity, nil, min: 1, step: 1, id: "quantity", class: "mt-1 focus:ring-blue-500 focus:border-blue-500 block shadow-sm sm:text-sm border-gray-300 rounded-md" %>
+  <%= number_field_tag :quantity, nil, min: 1, step: 1, id: "quantity",
+                        class: "mt-1 focus:ring-blue-500 focus:border-blue-500 block shadow-sm sm:text-sm border-gray-300 rounded-md",
+                        data: { turbo_permanent: true } %>
+
+  <% if defined?(errors) %>
+    <% errors.each do |error| %>
+      <div class="mt-2 text-red-600">
+        <span><%= error.full_message %></span>
+      </div>
+    <% end %>
+  <% end %>
 <% end %>

--- a/rails_application/test/integration/supplies_test.rb
+++ b/rails_application/test/integration/supplies_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class SuppliesTest < InMemoryRESIntegrationTestCase
+  def test_happy_path
+    product_id = register_product("Async Remote", 100, 10)
+
+    get "/products/#{product_id}/supplies/new"
+    assert_select "h1", "Supply"
+    post "/products/#{product_id}/supplies",
+          params: {
+            "authenticity_token" => "[FILTERED]",
+            "product_id" => product_id,
+            "quantity" => "1"
+          }
+    follow_redirect!
+
+    assert_select "#notice", "Stock level changed"
+  end
+
+  def test_renders_validation_error_when_quantity_is_not_present
+    product_id = register_product("Async Remote", 100, 10)
+
+    get "/products/#{product_id}/supplies/new"
+    assert_select "h1", "Supply"
+    post "/products/#{product_id}/supplies",
+          params: {
+            "authenticity_token" => "[FILTERED]",
+            "product_id" => product_id,
+            "quantity" => ""
+          }
+
+    assert_response :unprocessable_entity
+    assert_select "span", "Quantity can't be blank"
+  end
+
+  def test_renders_validation_error_when_quantity_is_not_a_number
+    product_id = register_product("Async Remote", 100, 10)
+
+    get "/products/#{product_id}/supplies/new"
+    assert_select "h1", "Supply"
+    post "/products/#{product_id}/supplies",
+          params: {
+            "authenticity_token" => "[FILTERED]",
+            "product_id" => product_id,
+            "quantity" => "not a number"
+          }
+
+    assert_response :unprocessable_entity
+    assert_select "span", "Quantity is not a number"
+  end
+
+  def test_renders_validation_error_when_quantity_is_zero
+    product_id = register_product("Async Remote", 100, 10)
+
+    get "/products/#{product_id}/supplies/new"
+    assert_select "h1", "Supply"
+    post "/products/#{product_id}/supplies",
+          params: {
+            "authenticity_token" => "[FILTERED]",
+            "product_id" => product_id,
+            "quantity" => "0"
+          }
+
+    assert_response :unprocessable_entity
+    assert_select "span", "Quantity must be greater than 0"
+  end
+end


### PR DESCRIPTION
Issue: https://github.com/RailsEventStore/ecommerce/issues/373

This PR adds BE validations for supply product form. This validations checks if the quantity is integer greater than 0 and if not, the proper validation error is rendered. 
![Zrzut ekranu 2024-08-14 o 13 51 28](https://github.com/user-attachments/assets/c7466506-f9b9-4c36-a0ea-3e489442aa03)
