### PR TITLE
Change VAT Rate code from integer to string

### DIFF
--- a/rails_application/app/controllers/products_controller.rb
+++ b/rails_application/app/controllers/products_controller.rb
@@ -6,12 +6,12 @@ class ProductsController < ApplicationController
 
     attribute :name, :string
     attribute :price, :decimal
-    attribute :vat_rate, :string
+    attribute :vat_rate_code, :string
     attribute :product_id, :string
 
     validates :name, presence: true
     validates :price, presence: true, numericality: { greater_than: 0 }
-    validates :vat_rate, presence: true, numericality: { greater_than: 0 }
+    validates :vat_rate_code, presence: true
     validates :product_id, presence: true
   end
 
@@ -43,8 +43,8 @@ class ProductsController < ApplicationController
       if product_form.price.present?
         set_product_price(product_form.product_id, product_form.price)
       end
-      if product_form.vat_rate.present?
-        set_product_vat_rate(product_form.product_id, product_form.vat_rate)
+      if product_form.vat_rate_code.present?
+        set_product_vat_rate(product_form.product_id, product_form.vat_rate_code)
       end
     end
 
@@ -91,8 +91,8 @@ class ProductsController < ApplicationController
     command_bus.(set_product_future_price_cmd(product_id, price, valid_since))
   end
 
-  def set_product_vat_rate(product_id, vat_rate)
-    command_bus.(set_product_vat_rate_cmd(product_id, vat_rate))
+  def set_product_vat_rate(product_id, vat_rate_code)
+    command_bus.(set_product_vat_rate_cmd(product_id, vat_rate_code))
   end
 
   def set_product_name(product_id, name)
@@ -111,8 +111,8 @@ class ProductsController < ApplicationController
     Pricing::SetPrice.new(product_id: product_id, price: price)
   end
 
-  def set_product_vat_rate_cmd(product_id, vat_rate)
-    Taxes::SetVatRate.new(product_id: product_id, vat_rate_code: vat_rate)
+  def set_product_vat_rate_cmd(product_id, vat_rate_code)
+    Taxes::SetVatRate.new(product_id: product_id, vat_rate_code: vat_rate_code)
   end
 
   def set_product_future_price_cmd(product_id, price, valid_since)
@@ -124,6 +124,6 @@ class ProductsController < ApplicationController
   end
 
   def product_params
-    params.permit(:name, :price, :vat_rate, :product_id).to_h.symbolize_keys.slice(:price, :vat_rate, :product_id, :name)
+    params.permit(:name, :price, :vat_rate_code, :product_id).to_h.symbolize_keys.slice(:price, :vat_rate_code, :name, :product_id)
   end
 end

--- a/rails_application/app/views/products/new.html.erb
+++ b/rails_application/app/views/products/new.html.erb
@@ -32,7 +32,7 @@
       <label for="vat_rate" class="block font-bold">
         VAT rate
       </label>
-      <%= select_tag :vat_rate, options_from_collection_for_select(VatRates::AvailableVatRate.all, :code, :code), class: "mt-1 focus:ring-blue-500 focus:border-blue-500 block shadow-sm sm:text-sm border-gray-300 rounded-md", data: { turbo_permanent: true } %>
+      <%= select_tag :vat_rate_code, options_from_collection_for_select(VatRates::AvailableVatRate.all, :code, :code), class: "mt-1 focus:ring-blue-500 focus:border-blue-500 block shadow-sm sm:text-sm border-gray-300 rounded-md", data: { turbo_permanent: true } %>
     </div>
 
     <% if defined?(errors) %>

--- a/rails_application/test/integration/products_test.rb
+++ b/rails_application/test/integration/products_test.rb
@@ -8,7 +8,7 @@ class ProductsTest < InMemoryRESIntegrationTestCase
   end
 
   def test_happy_path
-    add_available_vat_rate(10)
+    add_available_vat_rate(10, "10S")
     register_customer("Arkency")
     product_id = SecureRandom.uuid
 
@@ -20,7 +20,7 @@ class ProductsTest < InMemoryRESIntegrationTestCase
            "product_id" => product_id,
            "name" => "product name",
            :price => "20.01",
-           "vat_rate" => "10"
+           "vat_rate_code" => "10S"
          }
     follow_redirect!
 
@@ -59,7 +59,7 @@ class ProductsTest < InMemoryRESIntegrationTestCase
            "product_id" => product_id,
            "name" => "product name",
            "price" => "0",
-           "vat_rate" => "10"
+           "vat_rate_code" => "10"
          }
 
     assert_response :unprocessable_entity
@@ -77,30 +77,11 @@ class ProductsTest < InMemoryRESIntegrationTestCase
            "authenticity_token" => "[FILTERED]",
            "product_id" => product_id,
            "name" => "product name",
-           "price" => "100",
+           "price" => "100"
          }
 
     assert_response :unprocessable_entity
-    assert_select "span", "Vat rate can't be blank"
-  end
-
-  def test_does_not_crash_when_vat_rate_is_not_a_number
-    register_customer("Arkency")
-    product_id = SecureRandom.uuid
-
-    get "/products/new"
-    assert_select "h1", "New Product"
-    post "/products",
-         params: {
-           "authenticity_token" => "[FILTERED]",
-           "product_id" => product_id,
-           "name" => "product name",
-           "price" => "100",
-           "vat_rate" =>"abc"
-         }
-
-    assert_response :unprocessable_entity
-    assert_select "span", "Vat rate is not a number"
+    assert_select "span", "Vat rate code can't be blank"
   end
 
   def test_does_not_crash_when_name_is_not_present
@@ -114,7 +95,7 @@ class ProductsTest < InMemoryRESIntegrationTestCase
            "authenticity_token" => "[FILTERED]",
            "product_id" => product_id,
            "price" => "100",
-           "vat_rate" =>"10"
+           "vat_rate_code" =>"10"
          }
 
     assert_response :unprocessable_entity

--- a/rails_application/test/test_helper.rb
+++ b/rails_application/test/test_helper.rb
@@ -65,9 +65,9 @@ class InMemoryRESIntegrationTestCase < ActionDispatch::IntegrationTest
     customer_id
   end
 
-  def register_product(name, price, vat_rate)
+  def register_product(name, price, vat_rate_code)
     product_id = SecureRandom.uuid
-    post "/products", params: { product_id: product_id, name: name, price: price, vat_rate: vat_rate }
+    post "/products", params: { product_id: product_id, name: name, price: price, vat_rate_code: vat_rate_code }
     product_id
   end
 


### PR DESCRIPTION
Issue: https://github.com/RailsEventStore/ecommerce/issues/391 

I updated the product creation code to accept the VAT rate `code` as a string, aligning it with how VAT rates are created. Additionally, I renamed the attribute in the product form to `vat_rate_code` to better reflect that it represents the VAT rate code, not the entire VAT rate.