### PR TITLE
Display time promotion on order page

### DIFF
--- a/ecommerce/pricing/lib/pricing.rb
+++ b/ecommerce/pricing/lib/pricing.rb
@@ -11,6 +11,7 @@ require_relative "pricing/time_promotion"
 require_relative "pricing/promotions_calendar"
 require_relative "pricing/calculate_order_sub_amounts_value"
 require_relative "pricing/calculate_order_total_value"
+require_relative "pricing/apply_time_promotion"
 
 module Pricing
   def self.command_bus=(value)
@@ -90,7 +91,15 @@ module Pricing
         UseCoupon,
         UseCouponHandler.new(event_store)
       )
-      event_store.subscribe(CalculateOrderTotalValue, to: [
+      command_bus.register(
+        SetTimePromotionDiscount,
+        SetTimePromotionDiscountHandler.new(event_store)
+      )
+      command_bus.register(
+        ResetTimePromotionDiscount,
+        ResetTimePromotionDiscountHandler.new(event_store)
+      )
+      event_store.subscribe(ApplyTimePromotion, to: [
         PriceItemAdded,
         PriceItemRemoved,
         PercentageDiscountSet,
@@ -99,6 +108,17 @@ module Pricing
         ProductMadeFreeForOrder,
         FreeProductRemovedFromOrder
       ])
+      event_store.subscribe(CalculateOrderTotalValue, to: [
+        PriceItemAdded,
+        PriceItemRemoved,
+        PercentageDiscountSet,
+        PercentageDiscountReset,
+        PercentageDiscountChanged,
+        ProductMadeFreeForOrder,
+        FreeProductRemovedFromOrder,
+        TimePromotionDiscountSet,
+        TimePromotionDiscountReset
+      ])
       event_store.subscribe(CalculateOrderTotalSubAmountsValue, to: [
         PriceItemAdded,
         PriceItemRemoved,
@@ -106,7 +126,9 @@ module Pricing
         PercentageDiscountReset,
         PercentageDiscountChanged,
         ProductMadeFreeForOrder,
-        FreeProductRemovedFromOrder
+        FreeProductRemovedFromOrder,
+        TimePromotionDiscountSet,
+        TimePromotionDiscountReset
       ])
     end
   end

--- a/ecommerce/pricing/lib/pricing.rb
+++ b/ecommerce/pricing/lib/pricing.rb
@@ -115,9 +115,7 @@ module Pricing
         PercentageDiscountReset,
         PercentageDiscountChanged,
         ProductMadeFreeForOrder,
-        FreeProductRemovedFromOrder,
-        TimePromotionDiscountSet,
-        TimePromotionDiscountReset
+        FreeProductRemovedFromOrder
       ])
       event_store.subscribe(CalculateOrderTotalSubAmountsValue, to: [
         PriceItemAdded,
@@ -126,9 +124,7 @@ module Pricing
         PercentageDiscountReset,
         PercentageDiscountChanged,
         ProductMadeFreeForOrder,
-        FreeProductRemovedFromOrder,
-        TimePromotionDiscountSet,
-        TimePromotionDiscountReset
+        FreeProductRemovedFromOrder
       ])
     end
   end

--- a/ecommerce/pricing/lib/pricing/apply_time_promotion.rb
+++ b/ecommerce/pricing/lib/pricing/apply_time_promotion.rb
@@ -1,0 +1,23 @@
+module Pricing
+  class ApplyTimePromotion
+    def call(event)
+      discount = PromotionsCalendar.new(event_store).current_time_promotions_discount
+
+      if discount.exists?
+        command_bus.(SetTimePromotionDiscount.new(order_id: event.data.fetch(:order_id), amount: discount.value))
+      else
+        command_bus.(ResetTimePromotionDiscount.new(order_id: event.data.fetch(:order_id)))
+      end
+    end
+
+    private
+
+    def command_bus
+      Pricing.command_bus
+    end
+
+    def event_store
+      Pricing.event_store
+    end
+  end
+end

--- a/ecommerce/pricing/lib/pricing/apply_time_promotion.rb
+++ b/ecommerce/pricing/lib/pricing/apply_time_promotion.rb
@@ -8,6 +8,8 @@ module Pricing
       else
         command_bus.(ResetTimePromotionDiscount.new(order_id: event.data.fetch(:order_id)))
       end
+
+    rescue NotPossibleToAssignDiscountTwice, NotPossibleToResetWithoutDiscount
     end
 
     private

--- a/ecommerce/pricing/lib/pricing/commands.rb
+++ b/ecommerce/pricing/lib/pricing/commands.rb
@@ -45,6 +45,19 @@ module Pricing
     alias aggregate_id order_id
   end
 
+  class SetTimePromotionDiscount < Infra::Command
+    attribute :order_id, Infra::Types::UUID
+    attribute :amount, Infra::Types::PercentageDiscount
+
+    alias aggregate_id order_id
+  end
+
+  class ResetTimePromotionDiscount < Infra::Command
+    attribute :order_id, Infra::Types::UUID
+
+    alias aggregate_id order_id
+  end
+
   class RegisterCoupon < Infra::Command
     attribute :coupon_id, Infra::Types::UUID
     attribute :name, Infra::Types::String

--- a/ecommerce/pricing/lib/pricing/discounts.rb
+++ b/ecommerce/pricing/lib/pricing/discounts.rb
@@ -33,6 +33,10 @@ module Pricing
         PercentageDiscount.new(new_value)
       end
 
+      def ==(other)
+        value == other.value
+      end
+
       def exists?
         true
       end
@@ -57,7 +61,12 @@ module Pricing
         0
       end
 
+      def ==(other)
+        value == other.value
+      end
+
       def exists?
+        false
       end
     end
   end

--- a/ecommerce/pricing/lib/pricing/discounts.rb
+++ b/ecommerce/pricing/lib/pricing/discounts.rb
@@ -1,5 +1,8 @@
 module Pricing
   module Discounts
+    GENERAL_DISCOUNT = "general_discount"
+    TIME_PROMOTION_DISCOUNT = "time_promotion_discount"
+
     class UnacceptableDiscountRange < StandardError
     end
 
@@ -33,10 +36,6 @@ module Pricing
         PercentageDiscount.new(new_value)
       end
 
-      def ==(other)
-        value == other.value
-      end
-
       def exists?
         true
       end
@@ -57,16 +56,7 @@ module Pricing
         other_discount
       end
 
-      def value
-        0
-      end
-
-      def ==(other)
-        value == other.value
-      end
-
       def exists?
-        false
       end
     end
   end

--- a/ecommerce/pricing/lib/pricing/events.rb
+++ b/ecommerce/pricing/lib/pricing/events.rb
@@ -34,16 +34,8 @@ module Pricing
 
   class PercentageDiscountSet < Infra::Event
     attribute :order_id, Infra::Types::UUID
+    attribute :type, Infra::Types::String
     attribute :amount, Infra::Types::PercentageDiscount
-  end
-
-  class TimePromotionDiscountSet < Infra::Event
-    attribute :order_id, Infra::Types::UUID
-    attribute :amount, Infra::Types::PercentageDiscount
-  end
-
-  class TimePromotionDiscountReset < Infra::Event
-    attribute :order_id, Infra::Types::UUID
   end
 
   class PriceItemAdded < Infra::Event
@@ -58,10 +50,12 @@ module Pricing
 
   class PercentageDiscountReset < Infra::Event
     attribute :order_id, Infra::Types::UUID
+    attribute :type, Infra::Types::String
   end
 
   class PercentageDiscountChanged < Infra::Event
     attribute :order_id, Infra::Types::UUID
+    attribute :type, Infra::Types::String
     attribute :amount, Infra::Types::Price
   end
 

--- a/ecommerce/pricing/lib/pricing/events.rb
+++ b/ecommerce/pricing/lib/pricing/events.rb
@@ -34,7 +34,16 @@ module Pricing
 
   class PercentageDiscountSet < Infra::Event
     attribute :order_id, Infra::Types::UUID
-    attribute :amount, Infra::Types::Price
+    attribute :amount, Infra::Types::PercentageDiscount
+  end
+
+  class TimePromotionDiscountSet < Infra::Event
+    attribute :order_id, Infra::Types::UUID
+    attribute :amount, Infra::Types::PercentageDiscount
+  end
+
+  class TimePromotionDiscountReset < Infra::Event
+    attribute :order_id, Infra::Types::UUID
   end
 
   class PriceItemAdded < Infra::Event

--- a/ecommerce/pricing/lib/pricing/services.rb
+++ b/ecommerce/pricing/lib/pricing/services.rb
@@ -21,7 +21,7 @@ module Pricing
 
     def call(cmd)
       @repository.with_aggregate(Offer, cmd.aggregate_id) do |order|
-        order.apply_discount(Discounts::PercentageDiscount.new(cmd.amount))
+        order.apply_discount(Discounts::GENERAL_DISCOUNT, Discounts::PercentageDiscount.new(cmd.amount))
       end
     end
   end
@@ -33,7 +33,7 @@ module Pricing
 
     def call(cmd)
       @repository.with_aggregate(Offer, cmd.aggregate_id) do |order|
-        order.reset_discount
+        order.reset_discount(Discounts::GENERAL_DISCOUNT)
       end
     end
   end
@@ -45,7 +45,7 @@ module Pricing
 
     def call(cmd)
       @repository.with_aggregate(Offer, cmd.aggregate_id) do |order|
-        order.change_discount(Discounts::PercentageDiscount.new(cmd.amount))
+        order.change_discount(Discounts::GENERAL_DISCOUNT, Discounts::PercentageDiscount.new(cmd.amount))
       end
     end
   end
@@ -57,7 +57,7 @@ module Pricing
 
     def call(cmd)
       @repository.with_aggregate(Offer, cmd.aggregate_id) do |order|
-        order.apply_time_promotion_discount(Discounts::PercentageDiscount.new(cmd.amount))
+        order.apply_discount(Discounts::TIME_PROMOTION_DISCOUNT, Discounts::PercentageDiscount.new(cmd.amount))
       end
     end
   end
@@ -69,7 +69,7 @@ module Pricing
 
     def call(cmd)
       @repository.with_aggregate(Offer, cmd.aggregate_id) do |order|
-        order.reset_time_promotion_discount
+        order.reset_discount(Discounts::TIME_PROMOTION_DISCOUNT)
       end
     end
   end

--- a/ecommerce/pricing/test/apply_time_promotion_test.rb
+++ b/ecommerce/pricing/test/apply_time_promotion_test.rb
@@ -1,0 +1,90 @@
+require_relative "test_helper"
+
+module Pricing
+  class ApplyTimePromotionTest < Test
+    cover "Pricing*"
+
+    def test_applies_biggest_time_promotion_discount
+      order_id = SecureRandom.uuid
+      product_id = SecureRandom.uuid
+      create_inactive_time_promotion(60)
+      create_active_time_promotion(10)
+      create_active_time_promotion(50)
+      create_active_time_promotion(30)
+
+      assert_events_contain(stream_name(order_id), time_promotion_discount_set_event(order_id, 50)) do
+          Pricing::ApplyTimePromotion.new.call(item_added_to_basket_event(order_id, product_id))
+      end
+    end
+
+    def test_resets_time_promotion_discount
+      order_id = SecureRandom.uuid
+      product_id = SecureRandom.uuid
+      set_time_promotion_discount(order_id, 50)
+
+      assert_events_contain(stream_name(order_id), time_promotion_discount_reset_event(order_id)) do
+          Pricing::ApplyTimePromotion.new.call(item_added_to_basket_event(order_id, product_id))
+      end
+    end
+
+    private
+
+    def create_inactive_time_promotion(discount)
+      run_command(
+        Pricing::CreateTimePromotion.new(
+          time_promotion_id: SecureRandom.uuid,
+          discount: discount,
+          start_time: Time.current - 2,
+          end_time: Time.current - 1,
+          label: "Past Promotion"
+        )
+      )
+    end
+
+    def create_active_time_promotion(discount)
+      run_command(
+        Pricing::CreateTimePromotion.new(
+          time_promotion_id: SecureRandom.uuid,
+          discount: discount,
+          start_time: Time.current - 1,
+          end_time: Time.current + 1,
+          label: "Last Minute"
+        )
+      )
+    end
+
+    def item_added_to_basket_event(order_id, product_id)
+      Pricing::PriceItemAdded.new(
+        data: {
+          product_id: product_id,
+          order_id: order_id
+          }
+        )
+    end
+
+    def set_time_promotion_discount(order_id, discount)
+      run_command(SetTimePromotionDiscount.new(order_id: order_id, amount: 50))
+    end
+
+    def time_promotion_discount_set_event(order_id, amount)
+      TimePromotionDiscountSet.new(
+        data: {
+          order_id: order_id,
+          amount: amount
+        }
+      )
+    end
+
+    def time_promotion_discount_reset_event(order_id)
+      TimePromotionDiscountReset.new(
+        data: {
+          order_id: order_id
+        }
+      )
+    end
+
+    def stream_name(order_id)
+      "Pricing::Offer$#{order_id}"
+    end
+  end
+end

--- a/ecommerce/pricing/test/discounts_test.rb
+++ b/ecommerce/pricing/test/discounts_test.rb
@@ -55,20 +55,6 @@ module Pricing
 
         assert_equal(0, combined.apply(100))
       end
-
-      def test_is_equal_to_another_discount
-        first_discount = PercentageDiscount.new(50)
-        second_discount = PercentageDiscount.new(50)
-
-        assert_equal(first_discount, second_discount)
-      end
-
-      def test_is_not_equal_to_another_discount
-        first_discount = PercentageDiscount.new(50)
-        second_discount = PercentageDiscount.new(60)
-
-        refute_equal(first_discount, second_discount)
-      end
     end
 
     class NoPercentageDiscountTest < Test
@@ -76,24 +62,6 @@ module Pricing
 
       def test_doesnt_change_total
         assert_equal(100, NoPercentageDiscount.new.apply(100))
-      end
-
-      def test_is_equal_to_another_discount
-        first_discount = NoPercentageDiscount.new
-        second_discount = NoPercentageDiscount.new
-
-        assert_equal(first_discount, second_discount)
-      end
-
-      def test_is_not_equal_to_another_discount
-        first_discount = NoPercentageDiscount.new
-        second_discount = PercentageDiscount.new(50)
-
-        refute_equal(first_discount, second_discount)
-      end
-
-      def test_exists_returns_false
-        assert_equal false, NoPercentageDiscount.new.exists?
       end
     end
   end

--- a/ecommerce/pricing/test/discounts_test.rb
+++ b/ecommerce/pricing/test/discounts_test.rb
@@ -55,6 +55,20 @@ module Pricing
 
         assert_equal(0, combined.apply(100))
       end
+
+      def test_is_equal_to_another_discount
+        first_discount = PercentageDiscount.new(50)
+        second_discount = PercentageDiscount.new(50)
+
+        assert_equal(first_discount, second_discount)
+      end
+
+      def test_is_not_equal_to_another_discount
+        first_discount = PercentageDiscount.new(50)
+        second_discount = PercentageDiscount.new(60)
+
+        refute_equal(first_discount, second_discount)
+      end
     end
 
     class NoPercentageDiscountTest < Test
@@ -62,6 +76,24 @@ module Pricing
 
       def test_doesnt_change_total
         assert_equal(100, NoPercentageDiscount.new.apply(100))
+      end
+
+      def test_is_equal_to_another_discount
+        first_discount = NoPercentageDiscount.new
+        second_discount = NoPercentageDiscount.new
+
+        assert_equal(first_discount, second_discount)
+      end
+
+      def test_is_not_equal_to_another_discount
+        first_discount = NoPercentageDiscount.new
+        second_discount = PercentageDiscount.new(50)
+
+        refute_equal(first_discount, second_discount)
+      end
+
+      def test_exists_returns_false
+        assert_equal false, NoPercentageDiscount.new.exists?
       end
     end
   end

--- a/ecommerce/pricing/test/pricing_test.rb
+++ b/ecommerce/pricing/test/pricing_test.rb
@@ -93,6 +93,52 @@ module Pricing
       ) { calculate_sub_amounts(order_id) }
     end
 
+    def test_sets_time_promotion_discount
+      order_id = SecureRandom.uuid
+      stream = stream_name(order_id)
+
+      assert_events_contain(
+        stream,
+        TimePromotionDiscountSet.new(
+          data: {
+            order_id: order_id,
+            amount: 25
+          }
+        )
+      ) { set_time_promotion_discount(order_id, 25) }
+    end
+
+    def test_does_not_set_the_same_time_promotion_discount_twice
+      order_id = SecureRandom.uuid
+      stream = stream_name(order_id)
+      set_time_promotion_discount(order_id, 25)
+
+      assert_events(stream) { set_time_promotion_discount(order_id, 25) }
+    end
+
+    def test_resets_time_promotion_discount
+      order_id = SecureRandom.uuid
+      stream = stream_name(order_id)
+      set_time_promotion_discount(order_id, 25)
+
+
+      assert_events_contain(
+        stream,
+        TimePromotionDiscountReset.new(
+          data: {
+            order_id: order_id
+          }
+        )
+      ) { reset_time_promotion_discount(order_id) }
+    end
+
+    def test_does_not_reset_time_promotion_discount_if_there_is_none
+      order_id = SecureRandom.uuid
+      stream = stream_name(order_id)
+
+      assert_events(stream) { reset_time_promotion_discount(order_id) }
+    end
+
     def test_calculates_total_value_with_discount
       product_1_id = SecureRandom.uuid
       set_price(product_1_id, 20)

--- a/ecommerce/pricing/test/promotions_calendar_test.rb
+++ b/ecommerce/pricing/test/promotions_calendar_test.rb
@@ -1,0 +1,30 @@
+require_relative "test_helper"
+
+module Pricing
+  class PromotionsCalendarTest < Test
+    cover "Pricing::PromotionsCalendar*"
+
+    def test_time_promotion_running
+      time_current = Time.current
+      promotion = Pricing::PromotionsCalendar::Promotion.from_event(time_promotion_created_event(time_current))
+
+      assert(promotion.running?(time_current))
+      refute(promotion.running?(time_current + 1))
+      refute(promotion.running?(time_current - 2))
+      refute(promotion.running?(time_current + 2))
+    end
+
+    private
+
+    def time_promotion_created_event(time_current)
+      TimePromotionCreated.new(
+        data: {
+          time_promotion_id: SecureRandom.uuid,
+          start_time: time_current - 1,
+          end_time: time_current + 1,
+          discount: 10
+        }
+      )
+    end
+  end
+end

--- a/ecommerce/pricing/test/test_helper.rb
+++ b/ecommerce/pricing/test/test_helper.rb
@@ -42,6 +42,14 @@ module Pricing
       run_command(RegisterCoupon.new(coupon_id: uid, name: name, code: code, discount: discount))
     end
 
+    def set_time_promotion_discount(order_id, amount)
+      run_command(SetTimePromotionDiscount.new(order_id: order_id, amount: amount))
+    end
+
+    def reset_time_promotion_discount(order_id)
+      run_command(ResetTimePromotionDiscount.new(order_id: order_id))
+    end
+
     def fake_name
       "Fake name"
     end

--- a/ecommerce/pricing/test/time_promotion_test.rb
+++ b/ecommerce/pricing/test/time_promotion_test.rb
@@ -41,127 +41,73 @@ module Pricing
     cover "Pricing*"
 
     def test_calculates_total_value_with_time_promotion
-      timestamp = Time.utc(2022, 5, 30, 15, 33)
+      order_id = SecureRandom.uuid
+      product_1_id = SecureRandom.uuid
+      set_price(product_1_id, 20)
+      add_item(order_id, product_1_id)
+      stream = stream_name(order_id)
 
-      Timecop.freeze(timestamp) do
-        product_1_id = SecureRandom.uuid
-        set_price(product_1_id, 20)
-        order_id = SecureRandom.uuid
-        add_item(order_id, product_1_id)
-        stream = stream_name(order_id)
+      run_command(SetTimePromotionDiscount.new(order_id: order_id, amount: 50))
 
-        assert_events(
-          stream,
-          OrderTotalValueCalculated.new(
-            data: {
-              order_id: order_id,
-              discounted_amount: 20,
-              total_amount: 20
-            }
-          )
-        ) { calculate_total_value(order_id) }
-
-        # Current promotions
-        first_time_promotion_id = SecureRandom.uuid
-        start_time = timestamp - 1
-        end_time = timestamp + 1
-        set_time_promotion_range(first_time_promotion_id, start_time, end_time, 40)
-
-        time_promotion_id = SecureRandom.uuid
-        start_time = timestamp
-        end_time = timestamp + 1
-        set_time_promotion_range(time_promotion_id, start_time, end_time, 1)
-
-
-        time_promotion_id = SecureRandom.uuid
-        start_time = timestamp
-        end_time = timestamp + 1
-        set_time_promotion_range(time_promotion_id, start_time, end_time, 50)
-
-        # Not applicable promotions
-        set_not_applicable_promotions(timestamp)
-
-        assert_events(
-          stream,
-          OrderTotalValueCalculated.new(
-            data: {
-              order_id: order_id,
-              total_amount: 20,
-              discounted_amount: 10,
-            }
-          )
-        ) { calculate_total_value(order_id) }
-      end
+      assert_events_contain(
+        stream,
+        OrderTotalValueCalculated.new(
+          data: {
+            order_id: order_id,
+            total_amount: 20,
+            discounted_amount: 10
+          }
+        )
+      ) { calculate_total_value(order_id) }
     end
 
     def test_calculates_sub_amounts_with_combined_discounts
-      timestamp = Time.utc(2022, 5, 30, 15, 33)
-      Timecop.freeze(timestamp) do
+      product_1_id = SecureRandom.uuid
+      product_2_id = SecureRandom.uuid
+      set_price(product_1_id, 20)
+      set_price(product_2_id, 30)
+      order_id = SecureRandom.uuid
+      stream = stream_name(order_id)
+      data = {
+        time_promotion_id: SecureRandom.uuid,
+        discount: 50,
+        start_time: Time.current - 1,
+        end_time: Time.current + 1,
+        label: "Last Minute"
+      }
 
-        product_1_id = SecureRandom.uuid
-        product_2_id = SecureRandom.uuid
-        set_price(product_1_id, 20)
-        set_price(product_2_id, 30)
-        order_id = SecureRandom.uuid
-        stream = stream_name(order_id)
+      run_command(CreateTimePromotion.new(data))
 
-        assert_events(stream) { calculate_sub_amounts(order_id) }
+      add_item(order_id, product_1_id)
+      add_item(order_id, product_2_id)
+      add_item(order_id, product_2_id)
+      run_command(SetTimePromotionDiscount.new(order_id: order_id, amount: 50))
 
-        add_item(order_id, product_1_id)
-        add_item(order_id, product_2_id)
-        add_item(order_id, product_2_id)
-        assert_events(
-          stream,
-          PriceItemValueCalculated.new(
-            data: {
-              order_id: order_id,
-              product_id: product_1_id,
-              quantity: 1,
-              amount: 20,
-              discounted_amount: 20
-            }
-          ),
-          PriceItemValueCalculated.new(
-            data: {
-              order_id: order_id,
-              product_id: product_2_id,
-              quantity: 2,
-              amount: 60,
-              discounted_amount: 60
-            }
-          )
-        ) { calculate_sub_amounts(order_id) }
-        run_command(
-          Pricing::SetPercentageDiscount.new(order_id: order_id, amount: 10)
+      run_command(
+        Pricing::SetPercentageDiscount.new(order_id: order_id, amount: 10)
+      )
+
+      assert_events_contain(
+        stream,
+        PriceItemValueCalculated.new(
+          data: {
+            order_id: order_id,
+            product_id: product_1_id,
+            quantity: 1,
+            amount: 20,
+            discounted_amount: 8
+          }
+        ),
+        PriceItemValueCalculated.new(
+          data: {
+            order_id: order_id,
+            product_id: product_2_id,
+            quantity: 2,
+            amount: 60,
+            discounted_amount: 24
+          }
         )
-
-        first_time_promotion_id = SecureRandom.uuid
-        start_time = timestamp - 1
-        end_time = timestamp + 1
-        set_time_promotion_range(first_time_promotion_id, start_time, end_time, 50)
-
-        assert_events(
-          stream,
-          PriceItemValueCalculated.new(
-            data: {
-              order_id: order_id,
-              product_id: product_1_id,
-              quantity: 1,
-              amount: 20,
-              discounted_amount: 8
-            }
-          ),
-          PriceItemValueCalculated.new(
-            data: {
-              order_id: order_id,
-              product_id: product_2_id,
-              quantity: 2,
-              amount: 60,
-              discounted_amount: 24
-            }
-          )
-        ) { calculate_sub_amounts(order_id) }
-      end
+      ) { calculate_sub_amounts(order_id) }
     end
 
     def test_cant_create_twice

--- a/ecommerce/pricing/test/time_promotion_test.rb
+++ b/ecommerce/pricing/test/time_promotion_test.rb
@@ -46,6 +46,10 @@ module Pricing
       set_price(product_1_id, 20)
       add_item(order_id, product_1_id)
       stream = stream_name(order_id)
+      time_promotion_id = SecureRandom.uuid
+      start_time = Time.current - 1
+      end_time = Time.current + 1
+      set_time_promotion_range(time_promotion_id, start_time, end_time, 50)
 
       run_command(SetTimePromotionDiscount.new(order_id: order_id, amount: 50))
 
@@ -81,7 +85,6 @@ module Pricing
       add_item(order_id, product_1_id)
       add_item(order_id, product_2_id)
       add_item(order_id, product_2_id)
-      run_command(SetTimePromotionDiscount.new(order_id: order_id, amount: 50))
 
       run_command(
         Pricing::SetPercentageDiscount.new(order_id: order_id, amount: 10)

--- a/rails_application/app/read_models/orders/configuration.rb
+++ b/rails_application/app/read_models/orders/configuration.rb
@@ -46,6 +46,7 @@ module Orders
       event_store.subscribe(ExpireOrder.new, to: [Ordering::OrderExpired])
       event_store.subscribe(ConfirmOrder.new, to: [Fulfillment::OrderConfirmed])
       event_store.subscribe(CancelOrder.new, to: [Fulfillment::OrderCancelled])
+      event_store.subscribe(UpdateTimePromotionDiscountValue.new, to: [Pricing::TimePromotionDiscountSet])
 
 
       subscribe(

--- a/rails_application/app/read_models/orders/configuration.rb
+++ b/rails_application/app/read_models/orders/configuration.rb
@@ -46,8 +46,8 @@ module Orders
       event_store.subscribe(ExpireOrder.new, to: [Ordering::OrderExpired])
       event_store.subscribe(ConfirmOrder.new, to: [Fulfillment::OrderConfirmed])
       event_store.subscribe(CancelOrder.new, to: [Fulfillment::OrderCancelled])
-      event_store.subscribe(UpdateTimePromotionDiscountValue.new, to: [Pricing::TimePromotionDiscountSet])
-
+      event_store.subscribe(UpdateTimePromotionDiscountValue.new, to: [Pricing::PercentageDiscountSet])
+      event_store.subscribe(ResetTimePromotionDiscountValue.new, to: [Pricing::PercentageDiscountReset])
 
       subscribe(
         ->(event) { broadcast_order_state_change(event.data.fetch(:order_id), 'Submitted') },

--- a/rails_application/app/read_models/orders/reset_discount.rb
+++ b/rails_application/app/read_models/orders/reset_discount.rb
@@ -1,6 +1,8 @@
 module Orders
   class ResetDiscount
     def call(event)
+      return unless event.data.fetch(:type) == Pricing::Discounts::GENERAL_DISCOUNT
+
       order = Order.find_by_uid(event.data.fetch(:order_id))
       order.percentage_discount = nil
       order.save!

--- a/rails_application/app/read_models/orders/reset_time_promotion_discount_value.rb
+++ b/rails_application/app/read_models/orders/reset_time_promotion_discount_value.rb
@@ -1,0 +1,12 @@
+module Orders
+  class ResetTimePromotionDiscountValue
+    def call(event)
+      return unless event.data.fetch(:type) == Pricing::Discounts::TIME_PROMOTION_DISCOUNT
+
+      order = Order.find_by(uid: event.data.fetch(:order_id))
+
+      order.time_promotion_discount_value = nil
+      order.save!
+    end
+  end
+end

--- a/rails_application/app/read_models/orders/update_discount.rb
+++ b/rails_application/app/read_models/orders/update_discount.rb
@@ -1,6 +1,8 @@
 module Orders
   class UpdateDiscount
     def call(event)
+      return unless event.data.fetch(:type) == Pricing::Discounts::GENERAL_DISCOUNT
+
       order = Order.find_or_create_by(uid: event.data.fetch(:order_id))
       if is_newest_value?(event, order)
         order.percentage_discount = event.data.fetch(:amount)

--- a/rails_application/app/read_models/orders/update_time_promotion_discount_value.rb
+++ b/rails_application/app/read_models/orders/update_time_promotion_discount_value.rb
@@ -1,6 +1,8 @@
 module Orders
   class UpdateTimePromotionDiscountValue
     def call(event)
+      return unless event.data.fetch(:type) == Pricing::Discounts::TIME_PROMOTION_DISCOUNT
+
       order = Order.find_or_create_by(uid: event.data.fetch(:order_id))
 
       order.time_promotion_discount_value = event.data.fetch(:amount)

--- a/rails_application/app/read_models/orders/update_time_promotion_discount_value.rb
+++ b/rails_application/app/read_models/orders/update_time_promotion_discount_value.rb
@@ -1,0 +1,10 @@
+module Orders
+  class UpdateTimePromotionDiscountValue
+    def call(event)
+      order = Order.find_or_create_by(uid: event.data.fetch(:order_id))
+
+      order.time_promotion_discount_value = event.data.fetch(:amount)
+      order.save!
+    end
+  end
+end

--- a/rails_application/app/views/orders/show.html.erb
+++ b/rails_application/app/views/orders/show.html.erb
@@ -104,6 +104,12 @@
       <td class="py-2 text-right"><%= @order.percentage_discount %>%</td>
     </tr>
     <% end %>
+    <% if @order.time_promotion_discount_value %>
+    <tr class="border-t">
+      <td class="py-2" colspan="3">Time Promotion discount</td>
+      <td class="py-2 text-right"><%= @order.time_promotion_discount_value %>%</td>
+    </tr>
+    <% end %>
 
     <tr class="border-t">
       <td class="py-2" colspan="3">Total</td>

--- a/rails_application/db/migrate/20241002130622_rename_happy_hour_value_to_time_promotion_discount_value.rb
+++ b/rails_application/db/migrate/20241002130622_rename_happy_hour_value_to_time_promotion_discount_value.rb
@@ -1,0 +1,5 @@
+class RenameHappyHourValueToTimePromotionDiscountValue < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :orders, :happy_hour_value, :time_promotion_discount_value
+  end
+end

--- a/rails_application/db/schema.rb
+++ b/rails_application/db/schema.rb
@@ -160,7 +160,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_18_113912) do
     t.decimal "percentage_discount", precision: 8, scale: 2
     t.decimal "total_value", precision: 8, scale: 2
     t.decimal "discounted_value", precision: 8, scale: 2
-    t.decimal "happy_hour_value", precision: 8, scale: 2
+    t.decimal "time_promotion_discount_value", precision: 8, scale: 2
     t.datetime "total_value_updated_at"
     t.datetime "discount_updated_at"
     t.index ["uid"], name: "index_orders_on_uid", unique: true

--- a/rails_application/test/integration/orders_test.rb
+++ b/rails_application/test/integration/orders_test.rb
@@ -383,7 +383,7 @@ class OrdersTest < InMemoryRESIntegrationTestCase
       label: "Last Minute",
       discount: discount,
       start_time: Time.current - 1,
-      end_time: Time.current + 1
+      end_time: Time.current + 1.minute
     }
   end
 end

--- a/rails_application/test/integration/orders_test.rb
+++ b/rails_application/test/integration/orders_test.rb
@@ -250,7 +250,7 @@ class OrdersTest < InMemoryRESIntegrationTestCase
     async_remote_id = register_product("Async Remote", 39, 10)
     shopify_id = register_customer("Shopify")
 
-    create_current_time_promotion
+    create_active_time_promotion(50)
     post "/orders/#{order_id}/add_item?product_id=#{async_remote_id}"
 
     post "/orders",
@@ -264,6 +264,7 @@ class OrdersTest < InMemoryRESIntegrationTestCase
 
     assert_select("td", "$19.50")
     assert_select("dd", "Submitted")
+    assert_select("td", "50.0%")
   end
 
   private
@@ -377,12 +378,12 @@ class OrdersTest < InMemoryRESIntegrationTestCase
     post "/orders/#{order_id}/update_discount?amount=10"
   end
 
-  def create_current_time_promotion(discount: 50, start_time: Time.current - 1.day, end_time: Time.current + 1.day)
+  def create_active_time_promotion(discount)
     post "/time_promotions", params: {
       label: "Last Minute",
       discount: discount,
-      start_time: start_time,
-      end_time: end_time
+      start_time: Time.current - 1,
+      end_time: Time.current + 1
     }
   end
 end

--- a/rails_application/test/orders/broadcast_test.rb
+++ b/rails_application/test/orders/broadcast_test.rb
@@ -210,6 +210,7 @@ module Orders
         Pricing::PercentageDiscountSet.new(
           data: {
             order_id: order_1_id,
+            type: Pricing::Discounts::GENERAL_DISCOUNT,
             amount: 30
           }
         )
@@ -221,6 +222,7 @@ module Orders
         Pricing::PercentageDiscountSet.new(
           data: {
             order_id: order_id,
+            type: Pricing::Discounts::GENERAL_DISCOUNT,
             amount: 30
           }
         )

--- a/rails_application/test/orders/update_time_promotion_discount_value_test.rb
+++ b/rails_application/test/orders/update_time_promotion_discount_value_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+module Orders
+  class UpdateTimePromotionDiscountValueTest < InMemoryTestCase
+    cover "Orders*"
+
+    def test_updates_time_promotion_discount_value
+      customer_id = SecureRandom.uuid
+      product_id = SecureRandom.uuid
+      order_id = SecureRandom.uuid
+      create_active_time_promotion
+      customer_registered(customer_id)
+      prepare_product(product_id)
+      item_added_to_basket(order_id, product_id)
+
+      order = Orders::Order.find_by(uid: order_id)
+      assert_equal 50, order.time_promotion_discount_value
+    end
+
+    private
+
+    def item_added_to_basket(order_id, product_id)
+      event_store.publish(Pricing::PriceItemAdded.new(data: { product_id: product_id, order_id: order_id }))
+    end
+
+    def prepare_product(product_id)
+      run_command(
+        ProductCatalog::RegisterProduct.new(
+          product_id: product_id,
+          )
+      )
+      run_command(
+        ProductCatalog::NameProduct.new(
+          product_id: product_id,
+          name: "test"
+        )
+      )
+      run_command(Pricing::SetPrice.new(product_id: product_id, price: 50))
+    end
+
+    def customer_registered(customer_id)
+      event_store.publish(Crm::CustomerRegistered.new(data: { customer_id: customer_id, name: "Arkency" }))
+    end
+
+    def create_active_time_promotion
+      run_command(
+        Pricing::CreateTimePromotion.new(
+          time_promotion_id: SecureRandom.uuid,
+          discount: 50,
+          start_time: Time.current - 1,
+          end_time: Time.current + 1,
+          label: "Last Minute"
+        )
+      )
+    end
+
+    def event_store
+      Rails.configuration.event_store
+    end
+  end
+end


### PR DESCRIPTION
Issue: https://github.com/RailsEventStore/ecommerce/issues/407 

Time Promotions are now displayed on order show page. It currently works only on admin side. The client order show page will be adjusted in another PR. 

https://github.com/user-attachments/assets/dcb300e5-7be4-4c54-a525-68189f94ac40

**Combined discounts are displayed correctly as well:** 
<img width="1109" alt="Zrzut ekranu 2024-10-6 o 14 41 15" src="https://github.com/user-attachments/assets/fe286143-5d5f-45c6-8c35-260a54b96a9e">

