### PR TITLE
Fix rails c

### DIFF
--- a/rails_application/config/application.rb
+++ b/rails_application/config/application.rb
@@ -11,8 +11,10 @@ require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)
 
-class Application < Rails::Application
+class RailsApplication
+  class Application < Rails::Application
 
-  config.load_defaults 7.0
-  config.generators.system_tests = nil
+    config.load_defaults 7.0
+    config.generators.system_tests = nil
+  end
 end


### PR DESCRIPTION
Before while running `rails c` there was an error `undefined method ``underscore`` for nil (NoMethodError)`.  
![Zrzut ekranu 2024-10-7 o 10 16 54](https://github.com/user-attachments/assets/e00e3541-5e0b-4e0e-a0a3-6392b032db10)

It seems like the issue was caused by lack of proper namespacing for the `Application` class. 