### PR TITLE
get rid of destroy_all in tests

### DIFF
--- a/rails_application/test/client_authentication/create_test.rb
+++ b/rails_application/test/client_authentication/create_test.rb
@@ -4,11 +4,6 @@ module ClientAuthentication
   class CreateTest < InMemoryTestCase
     cover "Authentication*"
 
-    def setup
-      super
-      Account.destroy_all
-    end
-
     def test_set_create
       customer_id = SecureRandom.uuid
       product_id = SecureRandom.uuid

--- a/rails_application/test/client_authentication/set_password_test.rb
+++ b/rails_application/test/client_authentication/set_password_test.rb
@@ -4,11 +4,6 @@ module ClientAuthentication
   class SetPasswordTest < InMemoryTestCase
     cover "Authentication*"
 
-    def setup
-      super
-      Account.destroy_all
-    end
-
     def test_set_password
       customer_id = SecureRandom.uuid
       account_id = SecureRandom.uuid

--- a/rails_application/test/client_orders/customer_registered_test.rb
+++ b/rails_application/test/client_orders/customer_registered_test.rb
@@ -4,11 +4,6 @@ module ClientOrders
   class CustomerRegisteredTest < InMemoryTestCase
     cover "ClientOrders*"
 
-    def setup
-      super
-      Client.destroy_all
-    end
-
     def test_customer_registered
       event_store = Rails.configuration.event_store
 

--- a/rails_application/test/client_orders/item_added_to_basket_test.rb
+++ b/rails_application/test/client_orders/item_added_to_basket_test.rb
@@ -4,12 +4,6 @@ module ClientOrders
   class ItemAddedToBasketTest < InMemoryTestCase
     cover "ClientOrders*"
 
-    def setup
-      super
-      Order.destroy_all
-      OrderLine.destroy_all
-    end
-
     def test_add_new_item
       event_store = Rails.configuration.event_store
 

--- a/rails_application/test/client_orders/item_removed_from_basket_test.rb
+++ b/rails_application/test/client_orders/item_removed_from_basket_test.rb
@@ -4,13 +4,6 @@ module ClientOrders
   class ItemRemovedFromBasketTest < InMemoryTestCase
     cover "ClientOrders*"
 
-    def setup
-      super
-      Order.destroy_all
-      OrderLine.destroy_all
-      Product.destroy_all
-    end
-
     def test_remove_item_when_quantity_gt_1
       event_store = Rails.configuration.event_store
 

--- a/rails_application/test/client_orders/order_cancelled_test.rb
+++ b/rails_application/test/client_orders/order_cancelled_test.rb
@@ -4,12 +4,6 @@ module ClientOrders
   class OrderCancelledTest < InMemoryTestCase
     cover "ClientOrders*"
 
-    def setup
-      super
-      Client.destroy_all
-      Order.destroy_all
-    end
-
     def test_order_confirmed
       event_store = Rails.configuration.event_store
       customer_id = SecureRandom.uuid

--- a/rails_application/test/client_orders/order_expired_test.rb
+++ b/rails_application/test/client_orders/order_expired_test.rb
@@ -4,12 +4,6 @@ module ClientOrders
   class OrderExpiredTest < InMemoryTestCase
     cover "ClientOrders*"
 
-    def setup
-      super
-      Client.destroy_all
-      Order.destroy_all
-    end
-
     def test_order_expired
       event_store = Rails.configuration.event_store
       customer_id = SecureRandom.uuid

--- a/rails_application/test/client_orders/order_paid_test.rb
+++ b/rails_application/test/client_orders/order_paid_test.rb
@@ -4,12 +4,6 @@ module ClientOrders
   class OrderConfirmedTest < InMemoryTestCase
     cover "ClientOrders*"
 
-    def setup
-      super
-      Client.destroy_all
-      Order.destroy_all
-    end
-
     def test_order_confirmed
       event_store = Rails.configuration.event_store
       customer_id = SecureRandom.uuid

--- a/rails_application/test/client_orders/order_placed_test.rb
+++ b/rails_application/test/client_orders/order_placed_test.rb
@@ -4,12 +4,6 @@ module ClientOrders
   class OrderPlacedTest < InMemoryTestCase
     cover "ClientOrders*"
 
-    def setup
-      super
-      Client.destroy_all
-      Order.destroy_all
-    end
-
     def test_order_placed
       event_store = Rails.configuration.event_store
       customer_id = SecureRandom.uuid

--- a/rails_application/test/client_orders/update_paid_orders_summary_test.rb
+++ b/rails_application/test/client_orders/update_paid_orders_summary_test.rb
@@ -4,11 +4,6 @@ module ClientOrders
   class UpdatePaidOrdersSummaryTest < InMemoryTestCase
     cover "ClientOrders*"
 
-    def setup
-      super
-      Client.destroy_all
-    end
-
     def test_update_orders_summary
       customer_id = SecureRandom.uuid
       other_customer_id = SecureRandom.uuid

--- a/rails_application/test/customers/connect_account_test.rb
+++ b/rails_application/test/customers/connect_account_test.rb
@@ -4,11 +4,6 @@ module Customers
   class ConnectAccountTest < InMemoryTestCase
     cover "Customers"
 
-    def setup
-      super
-      Customer.destroy_all
-    end
-
     def test_first_register_then_connect
       customer_id = SecureRandom.uuid
       account_id = SecureRandom.uuid

--- a/rails_application/test/customers/customer_promoted_to_vip_test.rb
+++ b/rails_application/test/customers/customer_promoted_to_vip_test.rb
@@ -4,11 +4,6 @@ module Customers
   class CustomerPromotedToVipTest < InMemoryTestCase
     cover "Customers"
 
-    def setup
-      super
-      Customer.destroy_all
-    end
-
     def test_promote_customer_to_vip
       event_store = Rails.configuration.event_store
 

--- a/rails_application/test/customers/update_paid_orders_summary_test.rb
+++ b/rails_application/test/customers/update_paid_orders_summary_test.rb
@@ -4,11 +4,6 @@ module Customers
   class UpdatePaidOrdersSummaryTest < InMemoryTestCase
     cover "Customers"
 
-    def setup
-      super
-      Customer.destroy_all
-    end
-
     def test_update_orders_summary
       customer_id = SecureRandom.uuid
       other_customer_id = SecureRandom.uuid

--- a/rails_application/test/integration/client_orders_test.rb
+++ b/rails_application/test/integration/client_orders_test.rb
@@ -6,9 +6,6 @@ class ClientOrdersTests < InMemoryRESIntegrationTestCase
   def setup
     super
     Rails.configuration.payment_gateway.call.reset
-    ClientOrders::Client.destroy_all
-    ClientOrders::Order.destroy_all
-    Orders::Order.destroy_all
     add_available_vat_rate(10)
   end
 

--- a/rails_application/test/integration/discount_test.rb
+++ b/rails_application/test/integration/discount_test.rb
@@ -3,7 +3,6 @@ require "test_helper"
 class DiscountTest < InMemoryRESIntegrationTestCase
   def setup
     super
-    Orders::Order.destroy_all
     add_available_vat_rate(10)
   end
 

--- a/rails_application/test/integration/login_test.rb
+++ b/rails_application/test/integration/login_test.rb
@@ -1,11 +1,6 @@
 require "test_helper"
 
 class LoginTest < InMemoryRESIntegrationTestCase
-  def setup
-    super
-    Customers::Customer.destroy_all
-  end
-
   def test_login
     password = "1234qwer"
     customer_id = register_customer("Arkency")

--- a/rails_application/test/integration/orders_test.rb
+++ b/rails_application/test/integration/orders_test.rb
@@ -4,7 +4,6 @@ class OrdersTest < InMemoryRESIntegrationTestCase
   def setup
     super
     Rails.configuration.payment_gateway.call.reset
-    Orders::Order.destroy_all
     add_available_vat_rate(10)
   end
 

--- a/rails_application/test/invoices/invoices_test.rb
+++ b/rails_application/test/invoices/invoices_test.rb
@@ -4,13 +4,6 @@ module Invoices
   class InvoicesTest < InMemoryRESIntegrationTestCase
     cover "Invoices*"
 
-    def setup
-      super
-      Invoice.destroy_all
-      InvoiceItem.destroy_all
-      Order.destroy_all
-    end
-
     def test_create_draft_order_when_not_exists
       event_store = Rails.configuration.event_store
       order_id = SecureRandom.uuid

--- a/rails_application/test/orders/assign_customer_first_test.rb
+++ b/rails_application/test/orders/assign_customer_first_test.rb
@@ -4,12 +4,6 @@ module Orders
   class AssignCustomerFirstTest < InMemoryTestCase
     cover "Orders*"
 
-    def setup
-      super
-      Order.destroy_all
-      OrderLine.destroy_all
-    end
-
     def test_create_draft_order_when_not_exists
       event_store = Rails.configuration.event_store
       customer_id = SecureRandom.uuid

--- a/rails_application/test/orders/customer_registered_test.rb
+++ b/rails_application/test/orders/customer_registered_test.rb
@@ -4,11 +4,6 @@ module Orders
   class CustomerRegisteredTest < InMemoryTestCase
     cover "Orders*"
 
-    def setup
-      super
-      Customer.destroy_all
-    end
-
     def test_customer_registered
       event_store = Rails.configuration.event_store
 

--- a/rails_application/test/orders/item_added_to_basket_test.rb
+++ b/rails_application/test/orders/item_added_to_basket_test.rb
@@ -4,12 +4,6 @@ module Orders
   class ItemAddedToBasketTest < InMemoryTestCase
     cover "Orders*"
 
-    def setup
-      super
-      Order.destroy_all
-      OrderLine.destroy_all
-    end
-
     def test_add_new_item
       event_store = Rails.configuration.event_store
 

--- a/rails_application/test/orders/item_removed_from_basket_test.rb
+++ b/rails_application/test/orders/item_removed_from_basket_test.rb
@@ -4,13 +4,6 @@ module Orders
   class ItemRemovedFromBasketTest < InMemoryTestCase
     cover "Orders*"
 
-    def setup
-      super
-      Order.destroy_all
-      OrderLine.destroy_all
-      Product.destroy_all
-    end
-
     def test_remove_item_when_quantity_gt_1
       event_store = Rails.configuration.event_store
 

--- a/rails_application/test/orders/order_cancelled_test.rb
+++ b/rails_application/test/orders/order_cancelled_test.rb
@@ -4,12 +4,6 @@ module Orders
   class OrderCancelledTest < InMemoryTestCase
     cover "Orders*"
 
-    def setup
-      super
-      Customer.destroy_all
-      Order.destroy_all
-    end
-
     def test_cancel_confirmed_order
       event_store = Rails.configuration.event_store
       customer_id = SecureRandom.uuid

--- a/rails_application/test/orders/order_expired_test.rb
+++ b/rails_application/test/orders/order_expired_test.rb
@@ -4,11 +4,6 @@ module Orders
   class OrderExpiredTest < InMemoryTestCase
     cover "Orders*"
 
-    def setup
-      super
-      Order.destroy_all
-    end
-
     def test_expire_created_order
       event_store = Rails.configuration.event_store
 

--- a/rails_application/test/orders/order_paid_test.rb
+++ b/rails_application/test/orders/order_paid_test.rb
@@ -4,12 +4,6 @@ module Orders
   class OrderConfirmedTest < InMemoryTestCase
     cover "Orders*"
 
-    def setup
-      super
-      Customer.destroy_all
-      Order.destroy_all
-    end
-
     def test_order_confirmed
       event_store = Rails.configuration.event_store
       customer_id = SecureRandom.uuid

--- a/rails_application/test/orders/order_placed_test.rb
+++ b/rails_application/test/orders/order_placed_test.rb
@@ -5,12 +5,6 @@ module Orders
     include ActiveJob::TestHelper
     cover "Orders"
 
-    def setup
-      super
-      Order.destroy_all
-      OrderLine.destroy_all
-    end
-
     def test_create_when_not_exists
       event_store = Rails.configuration.event_store
 


### PR DESCRIPTION
Issue: https://github.com/RailsEventStore/ecommerce/issues/379

It looks like Rails automatically wraps tests in a database transaction that is rolled back after they finish ([rails testing 2.7](https://guides.rubyonrails.org/testing.html#transactions)), so we don't need `destroy_all` and any other strategy for this. 