### PR TITLE
Estime final price of an order for a client

### DIFF
--- a/rails_application/app/read_models/client_orders/order_handlers.rb
+++ b/rails_application/app/read_models/client_orders/order_handlers.rb
@@ -31,6 +31,22 @@ module ClientOrders
         order.discounted_value = event.data.fetch(:discounted_amount)
         order.total_value = event.data.fetch(:total_amount)
         order.save!
+
+        broadcast_update(order.order_uid, "total_value", number_to_currency(order.total_value))
+        broadcast_update(order.order_uid, "discounted_value", number_to_currency(order.discounted_value))
+      end
+
+      private
+
+      def broadcast_update(order_id, target, content)
+        Turbo::StreamsChannel.broadcast_update_to(
+          "client_orders_#{order_id}",
+          target: "client_orders_#{order_id}_#{target}",
+          html: content)
+      end
+
+      def number_to_currency(number)
+        ActiveSupport::NumberHelper.number_to_currency(number)
       end
     end
 

--- a/rails_application/app/read_models/client_orders/rendering/edit_order.rb
+++ b/rails_application/app/read_models/client_orders/rendering/edit_order.rb
@@ -6,31 +6,32 @@ module ClientOrders
       include ActionView::Helpers::UrlHelper
 
       def self.build(view_context, order_id)
+        order = ClientOrders::Order.find_or_initialize_by(order_uid: order_id) do |order|
+          order.total_value = 0
+          order.discounted_value = 0
+        end
         order_lines = ClientOrders::OrderLine.where(order_uid: order_id)
         products = ClientOrders::Product.all
-        new(Arbre::Context.new(nil, view_context)).build(order_id, order_lines, products)
+        time_promotions = TimePromotions::TimePromotion.current
+        new(Arbre::Context.new(nil, view_context)).build(order, order_lines, products, time_promotions)
       end
 
-      def build(order_id, order_lines, products, attributes = {})
+      def build(order, order_lines, products, time_promotions, attributes = {})
         super(attributes)
         div do
-          products_table(order_id, products, order_lines)
-          coupon_form(order_id)
-          submit_form(order_id)
+          products_table(order, products, order_lines, time_promotions)
+          coupon_form(order)
+          submit_form(order)
         end
       end
 
       private
 
-      def products_table(order_id, products, order_lines)
+      def products_table(order, products, order_lines, time_promotions)
         table class: "w-full" do
           headers_row
-          tbody do
-            text_node turbo_stream_from "client_orders_#{order_id}"
-            products.each do |product|
-              product_row(order_id, product, order_lines)
-            end
-          end
+          products_rows(order, products, order_lines)
+          footer_rows(order, time_promotions)
         end
       end
 
@@ -46,16 +47,34 @@ module ClientOrders
         end
       end
 
-      def product_row(order_id, product, order_lines)
+      def products_rows(order, products, order_lines)
+        tbody do
+          text_node turbo_stream_from "client_orders_#{order.order_uid}"
+          products.each do |product|
+            product_row(order, product, order_lines)
+          end
+        end
+      end
+
+      def product_row(order, product, order_lines)
         order_line = order_lines&.find { |order_line| order_line.product_id == product.uid }
         tr class: "border-b" do
           td(class: "py-2") { product.name }
           td(class: "py-2") { out_of_stock_badge unless product.available? }
           td(class: "py-2", id: "client_orders_#{product.uid}_product_quantity") { order_line.try(&:product_quantity) || 0 }
           td(class: "py-2") { number_to_currency(product.price) }
-          td(class: "py-2", id: "client_orders_#{product.uid}_value") { number_to_currency(order_line.try(&:value)) }
-          td(class: "py-2 text-right") { add_item_button(order_id, product.uid) }
-          td(class: "py-2 text-right", id: "client_orders_#{product.uid}_remove_item_button") { remove_item_button(order_id, product.uid) if order_line }
+          td(class: "py-2", id: "client_orders_#{product.uid}_value") { number_to_currency(order_line.try(&:value)) || "$0.00" }
+          td(class: "py-2 text-right") { add_item_button(order.order_uid, product.uid) }
+          td(class: "py-2 text-right", id: "client_orders_#{product.uid}_remove_item_button") { remove_item_button(order, product.uid) if order_line }
+        end
+      end
+
+      def footer_rows(order, time_promotions)
+        tfoot class:"border-t-4" do
+          before_discounts_row(order) if order.percentage_discount || time_promotions.any?
+          coupon_discount_row(order) if order.percentage_discount
+          time_promotions_rows(time_promotions)
+          total_row(order)
         end
       end
 
@@ -67,12 +86,42 @@ module ClientOrders
         button_to "Add", add_item_client_order_path(id: order_id, product_id: product_id), class: "hover:underline text-blue-500"
       end
 
-      def remove_item_button(order_id, product_id)
-        button_to "Remove", remove_item_client_order_path(id: order_id, product_id: product_id), class: "hover:underline text-blue-500"
+      def remove_item_button(order, product_id)
+        button_to "Remove", remove_item_client_order_path(id: order.order_uid, product_id: product_id), class: "hover:underline text-blue-500"
       end
 
-      def coupon_form(order_id)
-        form(action: use_coupon_client_order_path(id: order_id), method: :post, class: "inline-flex gap-4 mt-8") do
+      def before_discounts_row(order)
+        tr(class: "border-t") do
+          td(class: "py-2", colspan: 4) { "Before discounts" }
+          td(class: "py-2", id: "client_orders_#{order.order_uid}_total_value") { number_to_currency(order.total_value) }
+        end
+      end
+
+      def coupon_discount_row(order)
+        tr(class: "border-t") do
+          td(class: "py-2", colspan: 4) { "Coupon discount" }
+          td(class: "py-2", id: "client_orders_#{order.order_uid}_percentage_discount") { "#{order.percentage_discount}%" }
+        end
+      end
+
+      def time_promotions_rows(time_promotions)
+        time_promotions.each do |time_promotion|
+          tr(class: "border-t") do
+            td(class: "py-2", colspan: 4) { "Promotion: #{time_promotion.label} (if you buy before #{time_promotion.end_time})"}
+            td(class: "py-2") { "#{time_promotion.discount}%" }
+          end
+        end
+      end
+
+      def total_row(order)
+        tr(class: "border-t") do
+          td(class: "py-2", colspan: 4) { "Total" }
+          td(class: "py-2 font-bold", id: "client_orders_#{order.order_uid}_discounted_value") { number_to_currency(order.discounted_value) }
+        end
+      end
+
+      def coupon_form(order)
+        form(action: use_coupon_client_order_path(id: order.order_uid), method: :post, class: "inline-flex gap-4 mt-8") do
           input(
             id: "coupon_code",
             type: :text,
@@ -84,9 +133,9 @@ module ClientOrders
         end
       end
 
-      def submit_form(order_id)
+      def submit_form(order)
         form(id: "form", action: client_orders_path, method: :post) do
-          input(type: :hidden, name: :order_id, value: order_id)
+          input(type: :hidden, name: :order_id, value: order.order_uid)
           div(class: "mt-8") do
             input type: :submit, value: "Create Order", class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
           end


### PR DESCRIPTION
Issue: https://github.com/RailsEventStore/ecommerce/issues/98

Now as I client I can see estimated final price of an order and discounts I got before I place the order. 

Order without any discounts: 
<img width="1188" alt="Zrzut ekranu 2024-10-25 o 10 20 52" src="https://github.com/user-attachments/assets/262a2aa9-0aa5-4043-ae02-1d31db1ff85d">

Order with time promotion and coupon discount: 

https://github.com/user-attachments/assets/020b5939-3dfc-4715-ab9e-230a9d908486





