### PR TITLE
Display time promotion on client order page

### DIFF
--- a/ecommerce/pricing/test/apply_time_promotion_test.rb
+++ b/ecommerce/pricing/test/apply_time_promotion_test.rb
@@ -17,14 +17,14 @@ module Pricing
       end
     end
 
-    def test_resets_time_promotion_discount
+    def test_removes_time_promotion_discount
       order_id = SecureRandom.uuid
       product_id = SecureRandom.uuid
       create_active_time_promotion(50)
       set_time_promotion_discount(order_id, 50)
 
       Timecop.travel(1.minute.from_now) do
-        assert_events_contain(stream_name(order_id), percentage_discount_reset_event(order_id)) do
+        assert_events_contain(stream_name(order_id), percentage_discount_removed_event(order_id)) do
           Pricing::ApplyTimePromotion.new.call(item_added_to_basket_event(order_id, product_id))
         end
       end
@@ -79,7 +79,7 @@ module Pricing
       )
     end
 
-    def percentage_discount_reset_event(order_id)
+    def percentage_discount_removed_event(order_id)
       PercentageDiscountRemoved.new(
         data: {
           order_id: order_id,

--- a/ecommerce/pricing/test/pricing_test.rb
+++ b/ecommerce/pricing/test/pricing_test.rb
@@ -117,7 +117,7 @@ module Pricing
       assert_raises(NotPossibleToAssignDiscountTwice) { set_time_promotion_discount(order_id, 25) }
     end
 
-    def test_resets_time_promotion_discount
+    def test_removes_time_promotion_discount
       order_id = SecureRandom.uuid
       stream = stream_name(order_id)
       create_active_time_promotion(25)
@@ -296,7 +296,7 @@ module Pricing
       end
     end
 
-    def test_changing_discount_not_possible_when_discount_is_reset
+    def test_changing_discount_not_possible_when_discount_is_removed
       product_1_id = SecureRandom.uuid
       set_price(product_1_id, 20)
       order_id = SecureRandom.uuid
@@ -384,7 +384,7 @@ module Pricing
       end
     end
 
-    def test_resetting_discount_possible_when_discount_has_been_set_and_then_changed
+    def test_removing_discount_possible_when_discount_has_been_set_and_then_changed
       product_1_id = SecureRandom.uuid
       set_price(product_1_id, 20)
       order_id = SecureRandom.uuid
@@ -419,7 +419,7 @@ module Pricing
       end
     end
 
-    def test_resetting_with_missing_discount_not_possible
+    def test_removing_with_missing_discount_not_possible
       product_1_id = SecureRandom.uuid
       set_price(product_1_id, 20)
       order_id = SecureRandom.uuid

--- a/rails_application/app/read_models/client_orders/configuration.rb
+++ b/rails_application/app/read_models/client_orders/configuration.rb
@@ -55,6 +55,8 @@ module ClientOrders
       event_store.subscribe(ProductHandlers::ChangeProductPrice, to: [Pricing::PriceSet])
       event_store.subscribe(ProductHandlers::RegisterProduct, to: [ProductCatalog::ProductRegistered])
       event_store.subscribe(ProductHandlers::UpdateProductAvailability, to: [Inventory::AvailabilityChanged])
+      event_store.subscribe(OrderHandlers::UpdateTimePromotionDiscount, to: [Pricing::PercentageDiscountSet])
+      event_store.subscribe(OrderHandlers::RemoveTimePromotionDiscount, to: [Pricing::PercentageDiscountRemoved])
       event_store.subscribe(OrderHandlers::UpdateDiscount, to: [Pricing::PercentageDiscountSet, Pricing::PercentageDiscountChanged])
       event_store.subscribe(OrderHandlers::RemoveDiscount, to: [Pricing::PercentageDiscountRemoved])
       event_store.subscribe(OrderHandlers::UpdateOrderTotalValue, to: [Pricing::OrderTotalValueCalculated])

--- a/rails_application/app/read_models/client_orders/order_handlers.rb
+++ b/rails_application/app/read_models/client_orders/order_handlers.rb
@@ -32,7 +32,7 @@ module ClientOrders
         return unless event.data.fetch(:type) == Pricing::Discounts::TIME_PROMOTION_DISCOUNT
 
         order = Order.find_or_create_by!(order_uid: event.data.fetch(:order_id))
-        order.time_promotion_discount = event.data.fetch(:amount)
+        order.time_promotion_discount = { discount_value: event.data.fetch(:amount).to_f, type: Pricing::Discounts::TIME_PROMOTION_DISCOUNT }
         order.save!
       end
     end

--- a/rails_application/app/read_models/client_orders/order_handlers.rb
+++ b/rails_application/app/read_models/client_orders/order_handlers.rb
@@ -19,8 +19,20 @@ module ClientOrders
 
     class UpdateDiscount
       def call(event)
+        return unless event.data.fetch(:type) == Pricing::Discounts::GENERAL_DISCOUNT
+
         order = Order.find_or_create_by!(order_uid: event.data.fetch(:order_id))
         order.percentage_discount = event.data.fetch(:amount)
+        order.save!
+      end
+    end
+
+    class UpdateTimePromotionDiscount
+      def call(event)
+        return unless event.data.fetch(:type) == Pricing::Discounts::TIME_PROMOTION_DISCOUNT
+
+        order = Order.find_or_create_by!(order_uid: event.data.fetch(:order_id))
+        order.time_promotion_discount = event.data.fetch(:amount)
         order.save!
       end
     end
@@ -90,8 +102,20 @@ module ClientOrders
 
     class RemoveDiscount
       def call(event)
+        return unless event.data.fetch(:type) == Pricing::Discounts::GENERAL_DISCOUNT
+
         order = Order.find_by(order_uid: event.data.fetch(:order_id))
         order.percentage_discount = nil
+        order.save!
+      end
+    end
+
+    class RemoveTimePromotionDiscount
+      def call(event)
+        return unless event.data.fetch(:type) == Pricing::Discounts::TIME_PROMOTION_DISCOUNT
+
+        order = Order.find_by(order_uid: event.data.fetch(:order_id))
+        order.time_promotion_discount = nil
         order.save!
       end
     end

--- a/rails_application/app/read_models/client_orders/rendering/show_order.rb
+++ b/rails_application/app/read_models/client_orders/rendering/show_order.rb
@@ -99,7 +99,7 @@ module ClientOrders
       def time_promotion_row(order)
         tr class: "border-t" do
           td(class: "py-2", colspan: 3) { "Time promotion discount" }
-          td(class: "py-2 text-right") { "#{order.time_promotion_discount}%" }
+          td(class: "py-2 text-right") { "#{order.time_promotion_discount["discount_value"]}%" }
         end
       end
 

--- a/rails_application/app/read_models/client_orders/rendering/show_order.rb
+++ b/rails_application/app/read_models/client_orders/rendering/show_order.rb
@@ -77,6 +77,7 @@ module ClientOrders
         tfoot class: "border-t-4" do
           before_discounts_row(order) if order.discounted_value != order.total_value
           general_discount_row(order) if order.percentage_discount
+          time_promotion_row(order) if order.time_promotion_discount
           total_row(order)
         end
       end
@@ -92,6 +93,13 @@ module ClientOrders
         tr class: "border-t" do
           td(class: "py-2", colspan: 3) { "General discount" }
           td(class: "py-2 text-right") { "#{order.percentage_discount}%" }
+        end
+      end
+
+      def time_promotion_row(order)
+        tr class: "border-t" do
+          td(class: "py-2", colspan: 3) { "Time promotion discount" }
+          td(class: "py-2 text-right") { "#{order.time_promotion_discount}%" }
         end
       end
 

--- a/rails_application/db/migrate/20241129122521_add_time_promotion_discount_to_client_orders.rb
+++ b/rails_application/db/migrate/20241129122521_add_time_promotion_discount_to_client_orders.rb
@@ -1,5 +1,5 @@
 class AddTimePromotionDiscountToClientOrders < ActiveRecord::Migration[7.2]
   def change
-    add_column :client_orders, :time_promotion_discount, :decimal, precision: 8, scale: 2
+    add_column :client_orders, :time_promotion_discount, :jsonb
   end
 end

--- a/rails_application/db/migrate/20241129122521_add_time_promotion_discount_to_client_orders.rb
+++ b/rails_application/db/migrate/20241129122521_add_time_promotion_discount_to_client_orders.rb
@@ -1,0 +1,5 @@
+class AddTimePromotionDiscountToClientOrders < ActiveRecord::Migration[7.2]
+  def change
+    add_column :client_orders, :time_promotion_discount, :decimal, precision: 8, scale: 2
+  end
+end

--- a/rails_application/db/schema.rb
+++ b/rails_application/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_18_113912) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_29_122521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_18_113912) do
     t.decimal "percentage_discount", precision: 8, scale: 2
     t.decimal "total_value", precision: 8, scale: 2
     t.decimal "discounted_value", precision: 8, scale: 2
+    t.decimal "time_promotion_discount", precision: 8, scale: 2
   end
 
   create_table "clients", force: :cascade do |t|

--- a/rails_application/db/schema.rb
+++ b/rails_application/db/schema.rb
@@ -60,7 +60,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_29_122521) do
     t.decimal "percentage_discount", precision: 8, scale: 2
     t.decimal "total_value", precision: 8, scale: 2
     t.decimal "discounted_value", precision: 8, scale: 2
-    t.decimal "time_promotion_discount", precision: 8, scale: 2
+    t.jsonb "time_promotion_discount"
   end
 
   create_table "clients", force: :cascade do |t|

--- a/rails_application/test/client_orders/discount_test.rb
+++ b/rails_application/test/client_orders/discount_test.rb
@@ -55,7 +55,8 @@ module ClientOrders
       assert_equal(50, order.total_value)
       assert_equal(25, order.discounted_value)
       assert_nil(order.percentage_discount)
-      assert_equal(50, order.time_promotion_discount)
+      assert_equal(50, order.time_promotion_discount["discount_value"])
+      assert_equal("time_promotion_discount", order.time_promotion_discount["type"])
     end
 
     private

--- a/rails_application/test/client_orders/time_promotion_discount_test.rb
+++ b/rails_application/test/client_orders/time_promotion_discount_test.rb
@@ -16,7 +16,8 @@ module ClientOrders
       order = ClientOrders::Order.find_by(order_uid: order_id)
       assert_equal 50, order.total_value
       assert_equal 25, order.discounted_value
-      assert_equal 50, order.time_promotion_discount
+      assert_equal 50, order.time_promotion_discount["discount_value"]
+      assert_equal "time_promotion_discount", order.time_promotion_discount["type"]
       assert_nil order.percentage_discount
     end
 

--- a/rails_application/test/integration/client_orders_test.rb
+++ b/rails_application/test/integration/client_orders_test.rb
@@ -197,6 +197,7 @@ class ClientOrdersTests < InMemoryRESIntegrationTestCase
     as_client_add_item_to_basket_for_order(product_id, order_id)
     as_client_submit_order_for_customer(order_id)
 
+    assert_select "tr td", "50.0%"
     assert_select "tr td", "$2.00"
   end
 

--- a/rails_application/test/orders/discount_test.rb
+++ b/rails_application/test/orders/discount_test.rb
@@ -59,7 +59,7 @@ module Orders
       assert event_store.event_in_stream?(event_store.read.of_type([Pricing::PercentageDiscountRemoved]).last.event_id, "Orders$all")
     end
 
-    def test_does_not_remove_percentage_discount_when_time_promotion_reset
+    def test_does_not_remove_percentage_discount_when_removing_time_promotion
       customer_id = SecureRandom.uuid
       product_id = SecureRandom.uuid
       order_id = SecureRandom.uuid

--- a/rails_application/test/orders/remove_time_promotion_discount_test.rb
+++ b/rails_application/test/orders/remove_time_promotion_discount_test.rb
@@ -4,7 +4,7 @@ module Orders
   class RemoveTimePromotionDiscountTest < InMemoryTestCase
     cover "Orders*"
 
-    def test_resets_time_promotion_discount_value
+    def test_removes_time_promotion_discount_value
       customer_id = SecureRandom.uuid
       product_id = SecureRandom.uuid
       order_id = SecureRandom.uuid
@@ -20,7 +20,7 @@ module Orders
       end
     end
 
-    def test_does_not_reset_time_promotion_when_general_discount_reset
+    def test_does_not_removes_time_promotion_when_removing_general_discount
       customer_id = SecureRandom.uuid
       product_id = SecureRandom.uuid
       order_id = SecureRandom.uuid


### PR DESCRIPTION
Issue: https://github.com/RailsEventStore/ecommerce/issues/410 

Previously, when a client submitted an order and displayed this order, there was no information about the discounts he received. Now, on the client order show page, there is information about the discounts that were applied.
<img width="1136" alt="Zrzut ekranu 2024-12-2 o 12 43 37" src="https://github.com/user-attachments/assets/1358fd7d-be62-4b88-ac42-9993ea330403">

I also refactored some names that had "reset" to "remove", which I had overlooked during this pull request:
https://github.com/RailsEventStore/ecommerce/pull/422

I was thinking about creating another table for discounts, such as `client_orders_discounts`, and storing the discounts there instead of keeping them in the same table as `client_order` as it is now. What do you think about this? 