### PR TITLE
Add mutant timeout and coverage criteria

### DIFF
--- a/ecommerce/pricing/.mutant.yml
+++ b/ecommerce/pricing/.mutant.yml
@@ -4,6 +4,9 @@ integration: minitest
 usage: opensource
 coverage_criteria:
   process_abort: true
+  timeout: true
+mutation:
+  timeout: 2.0
 matcher:
   subjects:
     - Pricing*


### PR DESCRIPTION
* The ecommerce/pricing subproject has mutations that cause an infinite loop.
* The mutation testing engine was, at this point not configured to:

  A) terminate infintie loops (mutation.timeout setting) B) consider timeouts as a killed mutation (coverage_criteria.timeout = true)