### PR TITLE
Rename Refund to Return

### DIFF
--- a/ecommerce/ordering/lib/ordering/commands/add_item_to_return.rb
+++ b/ecommerce/ordering/lib/ordering/commands/add_item_to_return.rb
@@ -1,0 +1,11 @@
+module Ordering
+  class AddItemToReturn < Infra::Command
+    attribute :return_id, Infra::Types::UUID
+    attribute :order_id, Infra::Types::UUID
+    attribute :product_id, Infra::Types::UUID
+
+    alias aggregate_id return_id
+  end
+
+  AddItemToRefund = AddItemToReturn
+end

--- a/ecommerce/ordering/lib/ordering/commands/create_draft_return.rb
+++ b/ecommerce/ordering/lib/ordering/commands/create_draft_return.rb
@@ -1,0 +1,10 @@
+module Ordering
+  class CreateDraftReturn < Infra::Command
+    attribute :return_id, Infra::Types::UUID
+    attribute :order_id, Infra::Types::UUID
+
+    alias aggregate_id return_id
+  end
+
+  CreateDraftRefund = CreateDraftReturn
+end

--- a/ecommerce/ordering/lib/ordering/commands/remove_item_from_return.rb
+++ b/ecommerce/ordering/lib/ordering/commands/remove_item_from_return.rb
@@ -1,0 +1,11 @@
+module Ordering
+  class RemoveItemFromReturn < Infra::Command
+    attribute :return_id, Infra::Types::UUID
+    attribute :order_id, Infra::Types::UUID
+    attribute :product_id, Infra::Types::UUID
+
+    alias aggregate_id return_id
+  end
+
+  RemoveItemFromRefund = RemoveItemFromReturn
+end

--- a/ecommerce/ordering/lib/ordering/events/draft_return_created.rb
+++ b/ecommerce/ordering/lib/ordering/events/draft_return_created.rb
@@ -1,0 +1,14 @@
+module Ordering
+  class DraftReturnCreated < Infra::Event
+    attribute :return_id, Infra::Types::UUID
+    attribute :order_id, Infra::Types::UUID
+    attribute :returnable_products, Infra::Types::Array.of(
+      Infra::Types::Hash.schema(
+        product_id: Infra::Types::UUID,
+        quantity: Infra::Types::Integer
+      )
+    )
+  end
+
+  DraftRefundCreated = DraftReturnCreated
+end

--- a/ecommerce/ordering/lib/ordering/events/item_added_to_return.rb
+++ b/ecommerce/ordering/lib/ordering/events/item_added_to_return.rb
@@ -1,0 +1,9 @@
+module Ordering
+  class ItemAddedToReturn < Infra::Event
+    attribute :return_id, Infra::Types::UUID
+    attribute :order_id, Infra::Types::UUID
+    attribute :product_id, Infra::Types::UUID
+  end
+
+  ItemAddedToRefund = ItemAddedToReturn
+end

--- a/ecommerce/ordering/lib/ordering/events/item_removed_from_return.rb
+++ b/ecommerce/ordering/lib/ordering/events/item_removed_from_return.rb
@@ -1,0 +1,9 @@
+module Ordering
+  class ItemRemovedFromReturn < Infra::Event
+    attribute :return_id, Infra::Types::UUID
+    attribute :order_id, Infra::Types::UUID
+    attribute :product_id, Infra::Types::UUID
+  end
+
+  ItemRemovedFromRefund = ItemRemovedFromReturn
+end

--- a/ecommerce/ordering/lib/ordering/return.rb
+++ b/ecommerce/ordering/lib/ordering/return.rb
@@ -1,0 +1,75 @@
+module Ordering
+  class Return
+    include AggregateRoot
+
+    ExceedsOrderQuantityError = Class.new(StandardError)
+    ReturnHaveNotBeenRequestedForThisProductError = Class.new(StandardError)
+
+    def initialize(id)
+      @id = id
+      @return_items = ItemsList.new
+    end
+
+    def create_draft(order_id, returnable_products)
+      apply DraftReturnCreated.new(data: { return_id: @id, order_id: order_id, returnable_products: returnable_products })
+    end
+
+    def add_item(product_id)
+      raise ExceedsOrderQuantityError unless enough_items?(product_id)
+      apply ItemAddedToReturn.new(data: { return_id: @id, order_id: @order_id, product_id: product_id })
+    end
+
+    def remove_item(product_id)
+      raise ReturnHaveNotBeenRequestedForThisProductError unless @return_items.quantity(product_id).positive?
+      apply ItemRemovedFromReturn.new(data: { return_id: @id, order_id: @order_id, product_id: product_id })
+    end
+
+    on DraftReturnCreated do |event|
+      @order_id = event.data[:order_id]
+      @returnable_products = event.data[:returnable_products]
+    end
+
+    on ItemAddedToReturn do |event|
+      @return_items.increase_quantity(event.data[:product_id])
+    end
+
+    on ItemRemovedFromReturn do |event|
+      @return_items.decrease_quantity(event.data[:product_id])
+    end
+
+    private
+
+    def enough_items?(product_id)
+      @return_items.quantity(product_id) < returnable_quantity(product_id)
+    end
+
+    def returnable_quantity(product_id)
+      product = @returnable_products.find { |product| product.fetch(:product_id) == product_id }
+      product.fetch(:quantity)
+    end
+  end
+
+  class ItemsList
+    attr_reader :return_items
+
+    def initialize
+      @return_items = Hash.new(0)
+    end
+
+    def increase_quantity(product_id)
+      return_items[product_id] = quantity(product_id) + 1
+    end
+
+    def decrease_quantity(product_id)
+      return_items[product_id] -= 1
+      return_items.delete(product_id) if quantity(product_id).equal?(0)
+    end
+
+    def quantity(product_id)
+      return_items[product_id]
+    end
+  end
+
+  Refund = Return
+  RefundableProducts = ReturnableProducts if defined?(ReturnableProducts)
+end

--- a/ecommerce/ordering/lib/ordering/returnable_products.rb
+++ b/ecommerce/ordering/lib/ordering/returnable_products.rb
@@ -1,0 +1,20 @@
+module Ordering
+  class ReturnableProducts
+    def call(event_store, order_id)
+      accepted_event = event_store
+        .read.backward
+        .stream("Pricing::Offer$#{order_id}")
+        .of_type(Pricing::OfferAccepted)
+        .first
+
+      placed_event = event_store
+        .read
+        .stream("Fulfillment::Order$#{order_id}")
+        .first
+
+      accepted_event.data.fetch(:order_lines) if placed_event
+    end
+  end
+
+  RefundableProducts = ReturnableProducts
+end

--- a/ecommerce/ordering/lib/ordering/service.rb
+++ b/ecommerce/ordering/lib/ordering/service.rb
@@ -1,47 +1,51 @@
 module Ordering
-  class OnCreateDraftRefund
+  class OnCreateDraftReturn
     def initialize(event_store)
       @repository = Infra::AggregateRootRepository.new(event_store)
       @event_store = event_store
     end
 
     def call(command)
-      @repository.with_aggregate(Refund, command.aggregate_id) do |refund|
-        refund.create_draft(
+      @repository.with_aggregate(Return, command.aggregate_id) do |return_order|
+        return_order.create_draft(
           command.order_id,
-          refundable_products(command.order_id)
+          returnable_products(command.order_id)
           )
       end
     end
 
     private
 
-    def refundable_products(order_id)
-      RefundableProducts.new.call(@event_store, order_id)
+    def returnable_products(order_id)
+      ReturnableProducts.new.call(@event_store, order_id)
     end
   end
 
-  class OnAddItemToRefund
+  class OnAddItemToReturn
     def initialize(event_store)
       @repository = Infra::AggregateRootRepository.new(event_store)
     end
 
     def call(command)
-      @repository.with_aggregate(Refund, command.aggregate_id) do |refund|
-        refund.add_item(command.product_id)
+      @repository.with_aggregate(Return, command.aggregate_id) do |return_order|
+        return_order.add_item(command.product_id)
       end
     end
   end
 
-  class OnRemoveItemFromRefund
+  class OnRemoveItemFromReturn
     def initialize(event_store)
       @repository = Infra::AggregateRootRepository.new(event_store)
     end
 
     def call(command)
-      @repository.with_aggregate(Refund, command.aggregate_id) do |refund|
-        refund.remove_item(command.product_id)
+      @repository.with_aggregate(Return, command.aggregate_id) do |return_order|
+        return_order.remove_item(command.product_id)
       end
     end
   end
+
+  OnCreateDraftRefund = OnCreateDraftReturn
+  OnAddItemToRefund = OnAddItemToReturn
+  OnRemoveItemFromRefund = OnRemoveItemFromReturn
 end

--- a/rails_application/lib/transformations/refund_to_return_event_mapper.rb
+++ b/rails_application/lib/transformations/refund_to_return_event_mapper.rb
@@ -1,0 +1,55 @@
+module Transformations
+  class RefundToReturnEventMapper
+    def initialize(class_map)
+      @class_map = class_map
+    end
+
+    def dump(record)
+      record
+    end
+
+    def load(record)
+      old_class_name = record.event_type
+      new_class_name = @class_map.fetch(old_class_name, old_class_name)
+      
+      if old_class_name != new_class_name
+        transformed_data = transform_payload(record.data, old_class_name)
+        
+        RubyEventStore::Record.new(
+          event_id: record.event_id,
+          event_type: new_class_name,
+          data: transformed_data,
+          metadata: record.metadata,
+          timestamp: record.timestamp || Time.now.utc,
+          valid_at: record.valid_at || Time.now.utc
+        )
+      else
+        record
+      end
+    end
+
+    private
+
+    def transform_payload(data, old_class_name)
+      case old_class_name
+      when 'Ordering::DraftRefundCreated'
+        data = transform_refund_to_return_payload(data, :refund_id, :return_id)
+        transform_refund_to_return_payload(data, :refundable_products, :returnable_products)
+      when 'Ordering::ItemAddedToRefund', 'Ordering::ItemRemovedFromRefund'
+        transform_refund_to_return_payload(data, :refund_id, :return_id)
+      else
+        data
+      end
+    end
+
+    def transform_refund_to_return_payload(data, old_key, new_key)
+      if data.key?(old_key)
+        data_copy = data.dup
+        data_copy[new_key] = data_copy.delete(old_key)
+        data_copy
+      else
+        data
+      end
+    end
+  end
+end

--- a/rails_application/test/transformations/refund_to_return_event_mapper_test.rb
+++ b/rails_application/test/transformations/refund_to_return_event_mapper_test.rb
@@ -1,0 +1,145 @@
+require "test_helper"
+
+class RefundToReturnEventMapperTest < ActiveSupport::TestCase
+  def setup
+    @remapper = Transformations::RefundToReturnEventMapper.new(
+      'Ordering::DraftRefundCreated' => 'Ordering::DraftReturnCreated',
+      'Ordering::ItemAddedToRefund' => 'Ordering::ItemAddedToReturn',
+      'Ordering::ItemRemovedFromRefund' => 'Ordering::ItemRemovedFromReturn'
+    )
+  end
+
+  def test_maps_event_class_names
+    test_cases = [
+      ['Ordering::DraftRefundCreated', 'Ordering::DraftReturnCreated'],
+      ['Ordering::ItemAddedToRefund', 'Ordering::ItemAddedToReturn'],
+      ['Ordering::ItemRemovedFromRefund', 'Ordering::ItemRemovedFromReturn']
+    ]
+
+    test_cases.each do |old_name, expected_new_name|
+      event_data = {
+        event_type: old_name,
+        data: { id: SecureRandom.uuid },
+        metadata: {}
+      }
+      
+      result = @remapper.load(event_data)
+      
+      assert_equal expected_new_name, result[:event_type], "Failed to map #{old_name}"
+    end
+  end
+
+  def test_leaves_new_event_names_unchanged
+    new_event_data = {
+      event_type: 'Ordering::DraftReturnCreated',
+      data: { return_id: SecureRandom.uuid },
+      metadata: {}
+    }
+    
+    result = @remapper.load(new_event_data)
+    
+    assert_equal new_event_data, result
+  end
+
+  def test_leaves_unrelated_events_unchanged
+    unrelated_event_data = {
+      event_type: 'SomeOther::Event',
+      data: { id: SecureRandom.uuid },
+      metadata: {}
+    }
+    
+    result = @remapper.load(unrelated_event_data)
+    
+    assert_equal unrelated_event_data, result
+  end
+
+  def test_transforms_draft_created_payload_completely
+    refund_id = SecureRandom.uuid
+    order_id = SecureRandom.uuid
+    
+    old_event_data = {
+      event_type: 'Ordering::DraftRefundCreated',
+      data: { refund_id: refund_id, order_id: order_id, refundable_products: [] },
+      metadata: {}
+    }
+    
+    result = @remapper.load(old_event_data)
+    
+    assert_equal refund_id, result[:data][:return_id]
+    assert_equal [], result[:data][:returnable_products]
+    assert_nil result[:data][:refund_id]
+    assert_nil result[:data][:refundable_products]
+    assert_equal order_id, result[:data][:order_id]
+  end
+
+  def test_transforms_item_events_payload
+    refund_id = SecureRandom.uuid
+    
+    test_cases = [
+      'Ordering::ItemAddedToRefund', 
+      'Ordering::ItemRemovedFromRefund'
+    ]
+    
+    test_cases.each do |old_event_type|
+      old_event_data = {
+        event_type: old_event_type,
+        data: { refund_id: refund_id, order_id: SecureRandom.uuid, product_id: SecureRandom.uuid },
+        metadata: {}
+      }
+      
+      result = @remapper.load(old_event_data)
+      
+      assert_equal refund_id, result[:data][:return_id], "Failed to transform refund_id to return_id for #{old_event_type}"
+      assert_nil result[:data][:refund_id], "refund_id should be removed for #{old_event_type}"
+    end
+  end
+
+  def test_dump_returns_item_unchanged
+    event_data = {
+      event_type: 'Ordering::DraftReturnCreated',
+      data: { return_id: SecureRandom.uuid },
+      metadata: {}
+    }
+    
+    result = @remapper.dump(event_data)
+
+    assert_equal event_data, result
+  end
+
+  def test_event_store_with_simple_transformation
+    mapper = RubyEventStore::Mappers::PipelineMapper.new(
+      RubyEventStore::Mappers::Pipeline.new(
+        Transformations::RefundToReturnEventMapper.new(
+          'Ordering::DraftRefundCreated' => 'Ordering::DraftReturnCreated',
+          'Ordering::ItemAddedToRefund' => 'Ordering::ItemAddedToReturn',
+          'Ordering::ItemRemovedFromRefund' => 'Ordering::ItemRemovedFromReturn'
+        )
+      )
+    )
+    
+    event_store = RailsEventStore::Client.new(
+      repository: RubyEventStore::InMemoryRepository.new,
+      mapper: mapper
+    )
+
+    return_id = SecureRandom.uuid
+    order_id = SecureRandom.uuid
+
+    old_event = Ordering::ItemAddedToRefund.new(
+      data: { 
+        refund_id: return_id, 
+        order_id: order_id, 
+        product_id: SecureRandom.uuid
+      }
+    )
+
+    event_store.publish(old_event, stream_name: "Return$#{return_id}")
+
+    events = event_store.read.stream("Return$#{return_id}").to_a
+    
+    assert_equal 1, events.size
+    assert_equal 'Ordering::ItemAddedToReturn', events.first.class.name
+    assert_equal return_id, events.first.data[:return_id]
+    assert_nil events.first.data[:refund_id]
+  end
+end


### PR DESCRIPTION
- better name describes the acutal feature that is returing products not refunding money
- maintain backward compatibtility by transforming deprecated events classes and payloads