### PR TITLE
Change to simplified test setup

### DIFF
--- a/rails_application/test/test_helper.rb
+++ b/rails_application/test/test_helper.rb
@@ -7,25 +7,12 @@ ActiveJob::Base.logger = Logger.new(nil)
 
 class InMemoryTestCase < ActiveSupport::TestCase
 
-  def before_setup
-    result = super
-    @previous_event_store = Rails.configuration.event_store
-    @previous_command_bus = Rails.configuration.command_bus
-    Rails.configuration.event_store = Infra::EventStore.in_memory
-    Rails.configuration.command_bus = Arkency::CommandBus.new
+  Rails.configuration.event_store = Infra::EventStore.in_memory
+  Rails.configuration.command_bus = Arkency::CommandBus.new
 
-    Configuration.new.call(
-      Rails.configuration.event_store, Rails.configuration.command_bus
-    )
-    result
-  end
-
-  def before_teardown
-    result = super
-    Rails.configuration.event_store = @previous_event_store
-    Rails.configuration.command_bus = @previous_command_bus
-    result
-  end
+  Configuration.new.call(
+    Rails.configuration.event_store, Rails.configuration.command_bus
+  )
 
   def run_command(command)
     Rails.configuration.command_bus.call(command)


### PR DESCRIPTION
* These hooks can just be moved to boot time code without semantic difference reducing indirection.
* Makes the effect of the hooks be persisted between parallel exeuction on mutation runs and regular test runs.