### PR TITLE
Move app-specific RES configuration to rails_app

### DIFF
--- a/apps/rails_application/config/initializers/rails_event_store.rb
+++ b/apps/rails_application/config/initializers/rails_event_store.rb
@@ -2,9 +2,23 @@ require "rails_event_store"
 require "arkency/command_bus"
 
 require_relative "../../lib/configuration"
+require_relative "../../lib/transformations/refund_to_return_event_mapper"
 
 Rails.configuration.to_prepare do
-  Rails.configuration.event_store = Infra::EventStore.main
+  mapper = RubyEventStore::Mappers::PipelineMapper.new(
+    RubyEventStore::Mappers::Pipeline.new(
+      Infra::EventStore.preserve_types,
+      Transformations::RefundToReturnEventMapper.new(
+        'Ordering::DraftRefundCreated' => 'Ordering::DraftReturnCreated',
+        'Ordering::ItemAddedToRefund' => 'Ordering::ItemAddedToReturn',
+        'Ordering::ItemRemovedFromRefund' => 'Ordering::ItemRemovedFromReturn'
+      ),
+      RubyEventStore::Mappers::Transformation::SymbolizeMetadataKeys.new,
+      to_domain_event: RubyEventStore::Mappers::Transformation::DomainEvent.new
+    )
+  )
+
+  Rails.configuration.event_store = Infra::EventStore.main(mapper: mapper)
   Rails.configuration.command_bus = Arkency::CommandBus.new
 
   Configuration.new.call(Rails.configuration.event_store, Rails.configuration.command_bus)


### PR DESCRIPTION
## Summary                                                                             
  - Move RefundToReturnEventMapper configuration from infra to rails_application         
  - Make `Infra::EventStore.main` accept optional `mapper:` parameter                    
  - Expose `preserve_types` for apps building custom mappers

This keeps infra independent of specific applications, following proper DDD layering.  
                                                                                         
Closes #461 