### PR TITLE
Res 3.0 compatibility

### DIFF
--- a/domains/communication/lib/communication.rb
+++ b/domains/communication/lib/communication.rb
@@ -74,10 +74,10 @@ module Communication
       apply MessageRead.new(data: { message_id: message_id })
     end
 
-    def apply_message_sent(_)
+    on MessageSent do |_|
     end
 
-    def apply_message_read(_)
+    on MessageRead do |_|
     end
   end
 end

--- a/infra/lib/infra/event_store.rb
+++ b/infra/lib/infra/event_store.rb
@@ -19,7 +19,7 @@ module Infra
     def self.in_memory
       new(
         RubyEventStore::Client.new(
-          repository: RubyEventStore::InMemoryRepository.new(ensure_supported_any_usage: true)
+          repository: RubyEventStore::InMemoryRepository.new
         )
       )
     end
@@ -27,7 +27,7 @@ module Infra
     def self.in_memory_rails
       new(
         RailsEventStore::Client.new(
-          repository: RubyEventStore::InMemoryRepository.new(ensure_supported_any_usage: true)
+          repository: RubyEventStore::InMemoryRepository.new
         )
       )
     end


### PR DESCRIPTION
 Make ecommerce compatible with RailsEventStore 3.0

  RES 3.0 removes APIs that were deprecated in 2.x. This PR adapts ecommerce to
  the upcoming release so it keeps working once the deprecated code is gone. Two
  independent changes, one commit each.

  1. Drop removed ensure_supported_any_usage: keyword
  (infra/lib/infra/event_store.rb)

  RubyEventStore::InMemoryRepository#initialize no longer accepts the
  ensure_supported_any_usage: keyword in 3.0 — the "no mixing :any with a specific
  expected position" rule is now enforced unconditionally. Passing the keyword
  raised ArgumentError. We passed true, which is now the default, so simply
  dropping it preserves behaviour.

  2. Replace apply_* handlers with the on DSL
  (domains/communication/lib/communication.rb)

  RES 3.0 removed the apply_<event_name> state-handler naming convention; the
  default apply strategy now raises AggregateRoot::MissingHandler for it. The
  (empty) MessageSent / MessageRead handlers in Communication::Message were
  switched to the on EventClass do … end DSL.

  Compatibility

  Both changes are backward-compatible with 2.x — the on DSL and omitting the
  keyword both work on current RES, so this can be merged before 3.0 ships.