### PR TITLE
Fix mutate-changes failing on pull_request CI events

### DIFF
--- a/.github/workflows/pricing-mutate.yml
+++ b/.github/workflows/pricing-mutate.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Run incremental mutation testing
         run: make -C domains/pricing mutate-changes
         env:
-          GIT_BASE_SHA: ${{ github.event_name == 'push' && github.event.before || '' }}
+          GIT_BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}

--- a/.github/workflows/rails_application-mutate.yml
+++ b/.github/workflows/rails_application-mutate.yml
@@ -56,4 +56,4 @@ jobs:
           DATABASE_URL: "postgres://postgres:secret@localhost:5432/cqrs-es-sample-with-res_test"
           RAILS_ENV: test
           MUTANT_OPTS: --jobs 4
-          GIT_BASE_SHA: ${{ github.event_name == 'push' && github.event.before || '' }}
+          GIT_BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}

--- a/apps/rails_application/Makefile
+++ b/apps/rails_application/Makefile
@@ -26,7 +26,9 @@ else
 	@bundle exec mutant run $(MUTANT_OPTS)
 endif
 
-GIT_BASE_SHA := $(or $(GIT_BASE_SHA),$(shell git merge-base HEAD origin/master))
+# Fall back to merge-base when GIT_BASE_SHA is empty or the git null SHA
+# (push of a new branch sets github.event.before to 0000…0).
+GIT_BASE_SHA := $(or $(filter-out 0000000000000000000000000000000000000000,$(GIT_BASE_SHA)),$(shell git merge-base HEAD origin/master))
 
 mutate-changes: ## Run incremental mutation tests on changes
 	@echo "Running incremental mutation tests against $(GIT_BASE_SHA)..."

--- a/apps/rails_application/Makefile
+++ b/apps/rails_application/Makefile
@@ -26,7 +26,7 @@ else
 	@bundle exec mutant run $(MUTANT_OPTS)
 endif
 
-GIT_BASE_SHA ?= $(shell git merge-base HEAD origin/master)
+GIT_BASE_SHA := $(or $(GIT_BASE_SHA),$(shell git merge-base HEAD origin/master))
 
 mutate-changes: ## Run incremental mutation tests on changes
 	@echo "Running incremental mutation tests against $(GIT_BASE_SHA)..."

--- a/domains/pricing/Makefile
+++ b/domains/pricing/Makefile
@@ -1,4 +1,4 @@
-GIT_BASE_SHA ?= $(shell git merge-base HEAD origin/master)
+GIT_BASE_SHA := $(or $(GIT_BASE_SHA),$(shell git merge-base HEAD origin/master))
 
 install:
 	@bundle install

--- a/domains/pricing/Makefile
+++ b/domains/pricing/Makefile
@@ -1,4 +1,6 @@
-GIT_BASE_SHA := $(or $(GIT_BASE_SHA),$(shell git merge-base HEAD origin/master))
+# Fall back to merge-base when GIT_BASE_SHA is empty or the git null SHA
+# (push of a new branch sets github.event.before to 0000…0).
+GIT_BASE_SHA := $(or $(filter-out 0000000000000000000000000000000000000000,$(GIT_BASE_SHA)),$(shell git merge-base HEAD origin/master))
 
 install:
 	@bundle install


### PR DESCRIPTION
Fix mutate-changes failing on pull_request CI events

  Problem

  The pricing-mutate and rails_application-mutate workflows fail on every PR
  during mutant bootstrap:

  Running incremental mutation tests against ...        ← GIT_BASE_SHA is empty
  Mutant::Repository::Diff#touched_path: ...CommandStatus...
  (Mutant::Repository::Diff::Error)

  Root cause

  Both workflows set the base SHA like this:

  GIT_BASE_SHA: ${{ github.event_name == 'push' && github.event.before || '' }}

  On a pull_request event the ternary resolves to ''. The Makefiles default it
  with:

  GIT_BASE_SHA ?= $(shell git merge-base HEAD origin/master)

  but ?= only assigns when the variable is undefined — an env var exported as an
  empty string still counts as defined, so the merge-base fallback never runs.
  mutant run --since is then invoked with no base ref, and mutant's git-diff
  bootstrap raises Mutant::Repository::Diff::Error. This hits every PR (the
  workflows trigger on pull_request: [opened, reopened] with no path filter),
  independent of what the PR changes.

  Fix

  - Workflows (pricing-mutate.yml, rails_application-mutate.yml): on PRs use
  github.event.pull_request.base.sha instead of ''. Full history is already
  available via fetch-depth: 0, so the base commit is present for --since.
  - Makefiles (domains/pricing/Makefile, apps/rails_application/Makefile): compute
  the merge-base when GIT_BASE_SHA is set-but-empty using $(or
  $(GIT_BASE_SHA),$(shell git merge-base HEAD origin/master)), so a blank env can
  never reach mutant again (defense in depth, also helps local runs).

  Scope

  CI-only change, 4 files, 4 lines. No application code touched.

  🤖 Generated with Claude Code